### PR TITLE
Add CF 24D, 1089E/F, 1110D, 2167E; LeetCode 3889–3892; fix 1111B/1793B

### DIFF
--- a/src/codeforces/set0/set0/set020/set024/d/problem.md
+++ b/src/codeforces/set0/set0/set020/set024/d/problem.md
@@ -1,0 +1,250 @@
+# D. Broken robot
+
+You received as a gift a very clever robot walking on a rectangular board. Unfortunately, you understood that it is broken and behaves rather strangely (randomly). The board consists of `N` rows and `M` columns of cells. The robot is initially at some cell on the *i*-th row and the *j*-th column. Then at every step the robot could go to some other cell. The aim is to go to the bottommost (`N`-th) row.
+
+The robot can stay at its current cell, move to the left, move to the right, or move to the cell below the current one. If the robot is in the leftmost column it cannot move to the left, and if it is in the rightmost column it cannot move to the right. At every step, all possible moves are equally probable.
+
+Return the **expected number of steps** to reach the bottommost row.
+
+## Input
+
+On the first line you will be given two space-separated integers `N` and `M` (`1 ≤ N, M ≤ 1000`).
+
+On the second line you will be given another two space-separated integers `i` and `j` (`1 ≤ i ≤ N`, `1 ≤ j ≤ M`) — the initial row and column. Note that `(1, 1)` is the upper-left corner of the board and `(N, M)` is the bottom-right corner.
+
+## Output
+
+Output the expected number of steps on a line by itself, with at least 4 digits after the decimal point.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```
+10 10
+10 4
+```
+
+**Output**
+
+```
+0.0000000000
+```
+
+### Example 2
+
+**Input**
+
+```
+10 14
+5 14
+```
+
+**Output**
+
+```
+18.0038068653
+```
+
+
+### ideas
+1. 完全不知道咋做～
+
+## detailed explanation
+
+Let `E[r][c]` be the expected number of steps needed to reach the bottom row if the robot starts at row `r`, column `c`.
+
+Our target is `E[i][j]`.
+
+### 1. Base case
+
+If `r = N`, we are already on the bottom row, so
+
+- `E[N][c] = 0`
+
+for every column `c`.
+
+### 2. Write the expectation equation
+
+For a cell that is not on the bottom row, use the standard expectation formula:
+
+- `E = 1 + average(of all reachable next states)`
+
+because we spend one step immediately, then continue from the next position.
+
+The set of possible moves depends on the column:
+
+- stay in place
+- move left, if it exists
+- move right, if it exists
+- move down
+
+All possible moves are equally likely.
+
+### 3. Equations on one fixed row
+
+Assume row `r + 1` is already known, and we now want to compute all values on row `r`.
+
+For convenience let
+
+- `X[c] = E[r][c]`
+- `D[c] = E[r+1][c]`
+
+Then we solve for `X[1..M]`.
+
+#### Left border (`c = 1`)
+
+Possible moves are:
+
+- stay at `(r,1)`
+- move right to `(r,2)`
+- move down to `(r+1,1)`
+
+So
+
+- `X[1] = 1 + (X[1] + X[2] + D[1]) / 3`
+
+which becomes
+
+- `2 * X[1] - X[2] = 3 + D[1]`
+
+#### Middle cell (`1 < c < M`)
+
+Possible moves are:
+
+- stay
+- left
+- right
+- down
+
+So
+
+- `X[c] = 1 + (X[c-1] + X[c] + X[c+1] + D[c]) / 4`
+
+which becomes
+
+- `3 * X[c] - X[c-1] - X[c+1] = 4 + D[c]`
+
+#### Right border (`c = M`)
+
+Similarly,
+
+- `X[M] = 1 + (X[M-1] + X[M] + D[M]) / 3`
+
+which becomes
+
+- `2 * X[M] - X[M-1] = 3 + D[M]`
+
+### 4. This is a tridiagonal linear system
+
+For one row, all unknowns are `X[1], X[2], ..., X[M]`, and each equation only involves:
+
+- the current variable
+- its left neighbor
+- its right neighbor
+
+So the system is tridiagonal and can be solved in linear time.
+
+### 5. Linear-time elimination
+
+We express each variable in the form
+
+- `X[c] = a[c] * X[c+1] + b[c]`
+
+and eliminate from left to right.
+
+#### First column
+
+From
+
+- `2 * X[1] - X[2] = 3 + D[1]`
+
+we get
+
+- `X[1] = (1/2) * X[2] + (3 + D[1]) / 2`
+
+so
+
+- `a[1] = 1/2`
+- `b[1] = (3 + D[1]) / 2`
+
+#### General column
+
+Suppose
+
+- `X[c-1] = a[c-1] * X[c] + b[c-1]`
+
+Substitute it into
+
+- `3 * X[c] - X[c-1] - X[c+1] = 4 + D[c]`
+
+Then
+
+- `(3 - a[c-1]) * X[c] - X[c+1] = 4 + D[c] + b[c-1]`
+
+so
+
+- `X[c] = a[c] * X[c+1] + b[c]`
+
+with
+
+- `a[c] = 1 / (3 - a[c-1])`
+- `b[c] = (4 + D[c] + b[c-1]) / (3 - a[c-1])`
+
+### 6. Recover the last column and back-substitute
+
+For the last column,
+
+- `2 * X[M] - X[M-1] = 3 + D[M]`
+
+and since
+
+- `X[M-1] = a[M-1] * X[M] + b[M-1]`
+
+we get
+
+- `(2 - a[M-1]) * X[M] = 3 + D[M] + b[M-1]`
+
+thus
+
+- `X[M] = (3 + D[M] + b[M-1]) / (2 - a[M-1])`
+
+After that, recover all previous values by going right-to-left:
+
+- `X[c] = a[c] * X[c+1] + b[c]`
+
+### 7. Process rows from bottom to top
+
+The bottom row is already known:
+
+- all zeros
+
+Then compute row `N-1`, then `N-2`, and so on, until row `i`.
+
+Each row costs `O(M)`, so the full complexity is:
+
+- `O(N * M)` time
+- `O(M)` memory
+
+which easily fits the limits `N, M <= 1000`.
+
+### 8. Special case `M = 1`
+
+There is only one column, so the robot has only two possible moves:
+
+- stay
+- go down
+
+each with probability `1/2`.
+
+If the expected number of steps from one row above is `X`, then
+
+- `X = 1 + (X + D) / 2`
+
+which gives
+
+- `X = D + 2`
+
+So every remaining row contributes exactly `2` expected steps.

--- a/src/codeforces/set0/set0/set020/set024/d/solution.go
+++ b/src/codeforces/set0/set0/set020/set024/d/solution.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	var x, y int
+	fmt.Fscan(in, &n, &m)
+	fmt.Fscan(in, &x, &y)
+	fmt.Printf("%.10f\n", solve(n, m, x, y))
+}
+
+func solve(n, m, x, y int) float64 {
+	if x == n {
+		return 0
+	}
+
+	next := make([]float64, m)
+
+	if m == 1 {
+		for row := n - 1; row >= x; row-- {
+			next[0] += 2.0
+		}
+		return next[0]
+	}
+
+	cur := make([]float64, m)
+	a := make([]float64, m)
+	b := make([]float64, m)
+
+	for row := n - 1; row >= x; row-- {
+		// cur[j] = a[j] * cur[j+1] + b[j]
+		a[0] = 0.5
+		b[0] = (3.0 + next[0]) / 2.0
+		for j := 1; j < m-1; j++ {
+			den := 3.0 - a[j-1]
+			a[j] = 1.0 / den
+			b[j] = (4.0 + next[j] + b[j-1]) / den
+		}
+
+		cur[m-1] = (3.0 + next[m-1] + b[m-2]) / (2.0 - a[m-2])
+		for j := m - 2; j >= 0; j-- {
+			cur[j] = a[j]*cur[j+1] + b[j]
+		}
+
+		copy(next, cur)
+	}
+
+	return next[y-1]
+}

--- a/src/codeforces/set0/set0/set020/set024/d/solution_test.go
+++ b/src/codeforces/set0/set0/set020/set024/d/solution_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestSample1(t *testing.T) {
+	got := solve(10, 10, 10, 4)
+	if got != 0 {
+		t.Fatalf("expect 0, got %.10f", got)
+	}
+}
+
+func TestSample2(t *testing.T) {
+	got := solve(10, 14, 5, 14)
+	want := 18.0038068653
+	if diff(got, want) > 1e-8 {
+		t.Fatalf("expect %.10f, got %.10f", want, got)
+	}
+}
+
+func TestSingleColumn(t *testing.T) {
+	got := solve(7, 1, 3, 1)
+	want := 8.0
+	if diff(got, want) > 1e-9 {
+		t.Fatalf("expect %.10f, got %.10f", want, got)
+	}
+}
+
+func diff(a, b float64) float64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/src/codeforces/set1/set10/set108/set1089/e/problem.md
+++ b/src/codeforces/set1/set10/set108/set1089/e/problem.md
@@ -1,0 +1,47 @@
+# E. Easy Chess
+
+Elma is learning chess figures. She learned that a **rook** can move either horizontally or vertically. To enhance her understanding of rook movement, Elma's grandmother gave Elma an \(8 \times 8\) chessboard and asked her to find a way to move the rook from **a1** to **h8** making exactly \(n\) moves, so that all visited cells are different.
+
+A **visited cell** is the initial cell **a1** and each cell on which the rook lands after a move.
+
+## Input
+
+The input contains a single integer \(n\) (\(2 \le n \le 63\)) — the desired number of moves.
+
+## Output
+
+Output a space-separated list of \(n + 1\) visited cells in the order they are visited by the rook. All cells must be different. The list should start with **a1** and end with **h8**. A solution always exists.
+
+## key insights
+
+1. The board size is fixed: only `8 x 8 = 64` cells.
+   - So we do not need a complicated formula.
+   - It is enough to build one universal route and then extract the required length from it.
+
+2. Build a Hamiltonian path from `a1` to `h8`.
+   - Visit the first 6 columns in a vertical snake:
+     - `a1 -> a2 -> ... -> a8`
+     - `b8 -> b7 -> ... -> b1`
+     - and so on
+   - Then finish the last two columns `g` and `h` with a fixed 16-cell path from `g1` to `h8`.
+   - This gives one path visiting all 64 cells exactly once.
+
+3. Now we only need exactly `n` moves, i.e. exactly `n + 1` visited cells.
+   - Instead of using the whole Hamiltonian path, choose a subsequence of it.
+   - Keep the first cell `a1` and the last cell `h8`.
+   - For any two consecutive kept cells, they must lie on the same row or the same column, so the rook can jump directly between them in one move.
+
+4. Since the master path has only 64 cells, a tiny DP is enough.
+   - `reach[i][len]` = whether we can end at the `i`-th cell of the master path using exactly `len` kept cells.
+   - Transition from `j` to `i` if:
+     - `j < i`
+     - the two cells are in the same row or column
+     - `reach[j][len-1]` is true
+
+5. Store predecessors and reconstruct one valid subsequence of length `n + 1`.
+   - The output sequence itself is the visited cells.
+   - All cells are distinct because the master path uses each board cell once.
+
+6. Why this always works.
+   - For this specific 64-cell master path, every required length from `2` to `63` is reachable by such a subsequence.
+   - Therefore a valid answer always exists, exactly as the statement guarantees.

--- a/src/codeforces/set1/set10/set108/set1089/e/solution.go
+++ b/src/codeforces/set1/set10/set108/set1089/e/solution.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	res := solve(n)
+	fmt.Println(strings.Join(res, " "))
+}
+
+func solve(n int) []string {
+	path := buildPath()
+	m := len(path)
+
+	reach := make([][]bool, m)
+	pre := make([][]int, m)
+	for i := 0; i < m; i++ {
+		reach[i] = make([]bool, m+1)
+		pre[i] = make([]int, m+1)
+		for j := 0; j <= m; j++ {
+			pre[i][j] = -1
+		}
+	}
+
+	reach[0][1] = true
+	for i := 1; i < m; i++ {
+		for j := 0; j < i; j++ {
+			if !sameLine(path[i], path[j]) {
+				continue
+			}
+			for l := 2; l <= n+1; l++ {
+				if reach[j][l-1] && !reach[i][l] {
+					reach[i][l] = true
+					pre[i][l] = j
+				}
+			}
+		}
+	}
+
+	cur := m - 1
+	l := n + 1
+	ans := make([]string, 0, l)
+	for cur >= 0 && l > 0 {
+		ans = append(ans, cellName(path[cur]))
+		cur = pre[cur][l]
+		l--
+	}
+	reverse(ans)
+	return ans
+}
+
+func buildPath() []int {
+	var path []int
+	for col := 0; col < 6; col++ {
+		if col%2 == 0 {
+			for row := 0; row < 8; row++ {
+				path = append(path, col*8+row)
+			}
+		} else {
+			for row := 7; row >= 0; row-- {
+				path = append(path, col*8+row)
+			}
+		}
+	}
+
+	// A Hamiltonian path on the last two columns, from g1 to h8.
+	tail := []string{
+		"g1", "g2", "g3", "g4", "g5", "g6", "g8", "g7",
+		"h7", "h1", "h2", "h3", "h4", "h5", "h6", "h8",
+	}
+	for _, s := range tail {
+		path = append(path, parseCell(s))
+	}
+
+	return path
+}
+
+func sameLine(a, b int) bool {
+	return a/8 == b/8 || a%8 == b%8
+}
+
+func cellName(x int) string {
+	return fmt.Sprintf("%c%d", 'a'+x/8, x%8+1)
+}
+
+func parseCell(s string) int {
+	col := int(s[0] - 'a')
+	row := int(s[1] - '1')
+	return col*8 + row
+}
+
+func reverse[T any](arr []T) {
+	for i, j := 0, len(arr)-1; i < j; i, j = i+1, j-1 {
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+}

--- a/src/codeforces/set1/set10/set108/set1089/f/problem.md
+++ b/src/codeforces/set1/set10/set108/set1089/f/problem.md
@@ -1,0 +1,125 @@
+# F. Fractions
+
+You are given a positive integer `n`.
+
+Find a sequence of fractions `a_i` / `b_i` for `i = 1 … k` (where `a_i` and `b_i` are positive integers) for some `k` such that:
+
+- for each `i` from 1 to `k`, `b_i` divides `n`, and `1 < b_i < n`;
+- for each `i` from 1 to `k`, `1 ≤ a_i < b_i`;
+- `a_1/b_1 + a_2/b_2 + … + a_k/b_k = 1 - 1/n`.
+
+## Input
+
+The input consists of a single integer `n` (`2 ≤ n ≤ 10^9`).
+
+## Output
+
+In the first line print `YES` if there exists such a sequence of fractions or `NO` otherwise.
+
+If there exists such a sequence, the next lines should contain a description of the sequence in the following format.
+
+The second line should contain integer `k` (`1 ≤ k ≤ 100000`) — the number of elements in the sequence. It is guaranteed that if such a sequence exists, then there exists a sequence of length at most 100000.
+
+The next `k` lines should contain the fractions of the sequence with two integers `a_i` and `b_i` on each line.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```
+2
+```
+
+**Output**
+
+```
+NO
+```
+
+### Example 2
+
+**Input**
+
+```
+6
+```
+
+**Output**
+
+```
+YES
+2
+1 2
+1 3
+```
+
+## Note
+
+In the second example there is a sequence 1/2, 1/3 such that 1/2 + 1/3 = 1 − 1/6.
+
+
+### ideas
+1. got (n - 1) / n those b > 1 and n % b = 0
+2. 如果 n = 7, (prime number) => -1
+3. 假设 n = u * v, u < v
+4. a / u + b / v = (n - 1) / n
+5. a * v + b * u = n - 1
+6. b * u < n and a * v < n must hold
+7. b < v must hold (becase u * v = n)
+8. b * u + 1 要能整除v
+9. a * v + 1 要能整除u
+10. 感觉肯定有答案（但是怎么构造呢？）
+11. 比如n = 8, 1/2 + 1/4 => -1
+12. n = 10 => 1/2 + 2/5 = 9 / 10 => work
+13. n = 15 => 1/3 + 3/5 = 14/ 15 
+14. 这里让a = 1, 那么 v + b * u = n - 1
+15. v + b * u = u * v - 1
+16. v + 1 = u * (v - b)
+17. a * v+1是u得倍数
+18. 比如上面 (5 + 1) 是2的倍数，（5 + 1）是3的倍数
+19. 
+
+## key insights
+
+1. We want
+   - `a1 / b1 + a2 / b2 + ... = 1 - 1 / n = (n - 1) / n`
+   - and every denominator must be a proper divisor of `n`.
+
+2. If `n` is a prime power, the answer is impossible.
+   - Suppose all denominators divide `n = p^t`.
+   - Then every denominator is also a power of `p`.
+   - So every fraction has denominator a power of `p`, and after reducing to denominator `n`, each term contributes a multiple of `p`.
+   - Hence the whole numerator must be divisible by `p`.
+   - But the target numerator is `n - 1 = p^t - 1`, which is not divisible by `p`.
+   - Contradiction.
+
+3. So a solution can exist only if `n` has at least two distinct prime factors.
+
+4. In that case, two fractions are enough.
+   - Let `x` be one prime-power factor of `n`, and let `y = n / x`.
+   - Then `gcd(x, y) = 1`, and both `x` and `y` are proper divisors of `n`.
+   - We try to build
+     `a / x + b / y = (n - 1) / n`.
+
+5. Multiply by `n = x * y`:
+   - `a * y + b * x = x * y - 1`.
+
+6. Since `x` and `y` are coprime, we can solve this by choosing `a` modulo `x`.
+   - We need
+     `a * y ≡ -1 (mod x)`.
+   - Because `gcd(y, x) = 1`, `y` has an inverse modulo `x`.
+   - So we can compute
+     `a ≡ -y^{-1} (mod x)`,
+     and then derive
+     `b = (x * y - 1 - a * y) / x`.
+
+7. This construction always gives valid bounds:
+   - `1 <= a < x`
+   - `1 <= b < y`
+   - so both fractions are valid and their denominators are proper divisors of `n`.
+
+8. Therefore:
+   - `NO` iff `n` is a prime power
+   - otherwise `YES`, and a solution with exactly two fractions always exists.

--- a/src/codeforces/set1/set10/set108/set1089/f/solution.go
+++ b/src/codeforces/set1/set10/set108/set1089/f/solution.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int64
+	fmt.Fscan(in, &n)
+
+	ok, ans := solve(n)
+	if !ok {
+		fmt.Println("NO")
+		return
+	}
+
+	fmt.Println("YES")
+	fmt.Println(len(ans))
+	for _, cur := range ans {
+		fmt.Println(cur[0], cur[1])
+	}
+}
+
+func solve(n int64) (bool, [][2]int64) {
+	x := primePowerPart(n)
+	y := n / x
+	if x == 1 || y == 1 {
+		return false, nil
+	}
+
+	_, inv, _ := exgcd(y, x)
+	inv %= x
+	if inv < 0 {
+		inv += x
+	}
+
+	a := (x - inv) % x
+	if a == 0 {
+		a = x - 1
+	}
+	b := (n - 1 - a*y) / x
+
+	if !(1 <= a && a < x && 1 <= b && b < y) {
+		return false, nil
+	}
+
+	return true, [][2]int64{{a, x}, {b, y}}
+}
+
+func primePowerPart(n int64) int64 {
+	for p := int64(2); p*p <= n; p++ {
+		if n%p == 0 {
+			res := int64(1)
+			for n%p == 0 {
+				n /= p
+				res *= p
+			}
+			return res
+		}
+	}
+	return n
+}
+
+func exgcd(a, b int64) (g, x, y int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := exgcd(b, a%b)
+	return g, y1, x1-(a/b)*y1
+}

--- a/src/codeforces/set1/set10/set108/set1089/f/solution_test.go
+++ b/src/codeforces/set1/set10/set108/set1089/f/solution_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+func check(t *testing.T, n int64, expect bool) {
+	t.Helper()
+	ok, ans := solve(n)
+	if ok != expect {
+		t.Fatalf("expect %v, got %v for n = %d", expect, ok, n)
+	}
+	if !ok {
+		return
+	}
+
+	num := int64(0)
+	den := n
+	for _, cur := range ans {
+		a, b := cur[0], cur[1]
+		if !(1 <= a && a < b && 1 < b && b < n && n%b == 0) {
+			t.Fatalf("bad fraction %v for n = %d", cur, n)
+		}
+		num += a * (n / b)
+	}
+	if num != n-1 {
+		t.Fatalf("wrong sum %d/%d for n = %d", num, den, n)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	check(t, 2, false)
+}
+
+func TestSample2(t *testing.T) {
+	check(t, 6, true)
+}
+
+func TestPrimePowers(t *testing.T) {
+	for _, n := range []int64{3, 4, 5, 8, 9, 16, 25} {
+		check(t, n, false)
+	}
+}
+
+func TestComposite(t *testing.T) {
+	for _, n := range []int64{10, 12, 15, 18, 20, 30, 42} {
+		check(t, n, true)
+	}
+}

--- a/src/codeforces/set1/set11/set111/set1110/d/problem.md
+++ b/src/codeforces/set1/set11/set111/set1110/d/problem.md
@@ -1,0 +1,117 @@
+# D. Jongmah
+
+You are playing a game of Jongmah. You don't need to know the rules to solve this problem. You have \(n\) tiles in your hand. Each tile has an integer between \(1\) and \(m\) written on it.
+
+To win the game, you will need to form some number of **triples**. Each triple consists of three tiles, such that the numbers written on the tiles are either all the same or consecutive. For example, \(7, 7, 7\) is a valid triple, and so is \(12, 13, 14\), but \(2, 2, 3\) or \(2, 4, 6\) are not. You can only use the tiles in your hand to form triples. Each tile can be used in at most one triple.
+
+To determine how close you are to the win, you want to know the **maximum number of triples** you can form from the tiles in your hand.
+
+## Input
+
+The first line contains two integers \(n\) and \(m\) (\(1 \le n, m \le 10^6\)) — the number of tiles in your hand and the number of tile types.
+
+The second line contains \(n\) integers \(a_1, a_2, \ldots, a_n\) (\(1 \le a_i \le m\)), where \(a_i\) denotes the number written on the \(i\)-th tile.
+
+## Output
+
+Print one integer: the maximum number of triples you can form.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```
+10 6
+2 3 3 3 4 4 4 5 5 6
+```
+
+**Output**
+
+```
+3
+```
+
+### Example 2
+
+**Input**
+
+```
+12 6
+1 5 3 3 3 4 3 5 3 2 3 3
+```
+
+**Output**
+
+```
+3
+```
+
+### Example 3
+
+**Input**
+
+```
+13 5
+1 1 5 1 2 3 3 2 4 2 3 4 5
+```
+
+**Output**
+
+```
+4
+```
+
+## Note
+
+In the first example, we have tiles \(2, 3, 3, 3, 4, 4, 4, 5, 5, 6\). We can form three triples in the following way: \(2, 3, 4\); \(3, 4, 5\); \(4, 5, 6\). Since there are only \(10\) tiles, there is no way we could form \(4\) triples, so the answer is \(3\).
+
+In the second example, we have tiles \(1\), \(2\), \(3\) (seven times), \(4\), \(5\) (two times). We can form three triples as follows: \(1, 2, 3\); \(3, 3, 3\); \(3, 4, 5\). One can show that forming four triples is not possible.
+
+
+### ideas
+1. sort a
+2. dp[i][0/1][x] 表示处理完i后, i作为递增序列中的第1个数（0），且剩余了x个时的最优解
+3. dp[i][0][x] 表示作为第一个数，剩余x时的最优解
+4. dp[i][1][x] 表示作为第二哥数，剩余x时的最优解
+5. 这里x不会超过3
+
+## summary
+
+1. Count how many times each value appears.
+   - After sorting, process equal values in one batch.
+   - Let `cnt` be the number of copies of the current value `x`.
+
+2. The only hard part is handling consecutive triples.
+   - A triple `(x-2, x-1, x)` consumes one copy of the current value.
+   - So when we arrive at value `x`, the only information that matters from the past is:
+     - how many unfinished groups already have `(x-2, x-1)` and are waiting for `x`
+     - how many unfinished groups already have `(x-1)` and will become waiting groups for `x+1`
+
+3. DP state.
+   - `dp[d0][d1]` = maximum number of triples formed so far
+   - `d0` is how many groups are currently waiting for the current value to finish a triple
+   - `d1` is how many groups use the current value as their middle element and will wait for the next value
+   - Each of `d0, d1` is at most `2`
+   - Reason: keeping `3` unfinished groups is never useful, because three equal values can already form one same-number triple.
+
+4. Transition at one value with frequency `cnt`.
+   - First satisfy the `d0` old groups that must take this value.
+   - Then keep `d1` copies to serve as the second element of triples continuing to the next value.
+   - Then optionally start `d2` new groups where the current value is the first element of a future consecutive triple.
+   - The remaining tiles can only be used as same-value triples, contributing `(remaining / 3)`.
+   - Completing the `d0` old groups adds exactly `d0` new triples.
+
+5. Why values only up to `2` are enough in the state.
+   - If there are `3` or more identical "unfinished obligations" of the same type, we can replace any `3` of them by one completed same-value triple without making future transitions worse.
+   - So capping the carry state at `2` is safe and keeps the DP constant-sized.
+
+6. There is one extra case when the current value is not consecutive to the previous processed value.
+   - Then no old consecutive chains can continue across this gap.
+   - We just take the best previous DP value, spend `d1` copies to start new chains from here, and convert the rest into same-value triples.
+
+7. Complexity.
+   - Sort once: `O(n log n)`.
+   - For each distinct value, try only states `0..2`, so transitions are `O(1)`.
+   - Total complexity: `O(n log n)`.

--- a/src/codeforces/set1/set11/set111/set1110/d/solution.go
+++ b/src/codeforces/set1/set11/set111/set1110/d/solution.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	res := drive(reader)
+	fmt.Println(res)
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+const inf = 1 << 60
+
+func solve(a []int) int {
+	slices.Sort(a)
+
+	dp := make([][]int, 3)
+	ndp := make([][]int, 3)
+
+	for i := range 3 {
+		dp[i] = make([]int, 3)
+		ndp[i] = make([]int, 3)
+		for j := range 3 {
+			dp[i][j] = -inf
+			ndp[i][j] = -inf
+		}
+	}
+
+	dp[0][0] = 0
+
+	n := len(a)
+	for i := 0; i < n; {
+		j := i
+		for i < n && a[i] == a[j] {
+			i++
+		}
+
+		cnt := i - j
+
+		if j > 0 && a[j-1] == a[j]-1 {
+			for d0 := range 3 {
+				for d1 := range 3 {
+					// (?, d0, ?) and (d1, ?, ?)
+					if d0+d1 <= cnt {
+						for d2 := 0; d2 < 3 && d0+d1+d2 <= cnt; d2++ {
+							// d2是作为(x,y,z)的开始的数量
+							ndp[d1][d2] = max(ndp[d1][d2], dp[d0][d1]+d0+(cnt-d0-d1-d2)/3)
+						}
+					}
+				}
+			}
+		}
+
+		var tmp int
+		for d0 := range 3 {
+			for d1 := range 3 {
+				tmp = max(tmp, dp[d0][d1])
+			}
+		}
+		for d1 := 0; d1 < 3 && d1 <= cnt; d1++ {
+			ndp[0][d1] = max(ndp[0][d1], tmp+(cnt-d1)/3)
+		}
+
+		for d0 := range 3 {
+			for d1 := range 3 {
+				dp[d0][d1] = ndp[d0][d1]
+				ndp[d0][d1] = -inf
+			}
+		}
+	}
+
+	var res int
+	for d0 := range 3 {
+		for d1 := range 3 {
+			res = max(res, dp[d0][d1])
+		}
+	}
+	return res
+}

--- a/src/codeforces/set1/set11/set111/set1110/d/solution_test.go
+++ b/src/codeforces/set1/set11/set111/set1110/d/solution_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `10 6
+2 3 3 3 4 4 4 5 5 6
+`
+	// 2 3 4
+	// 3 4 5
+	// 4 5 6
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `12 6
+1 5 3 3 3 4 3 5 3 2 3 3
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+
+func TestSample3(t *testing.T) {
+	s := `13 5
+1 1 5 1 2 3 3 2 4 2 3 4 5
+`
+	expect := 4
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set1/set11/set111/set1111/b/solution.go
+++ b/src/codeforces/set1/set11/set111/set1111/b/solution.go
@@ -25,7 +25,7 @@ func solve(a []int, m int, k int) float64 {
 
 	slices.Sort(a)
 
-	best := float64(sum) / float64(n)
+	best := float64(sum+min(m, n*k)) / float64(n)
 
 	for rem := 0; rem < m && rem+1 < n; rem++ {
 		// 剩余 n - rem - 1 个人可以进行最多 (n - rem - 1) * k

--- a/src/codeforces/set1/set17/set179/set1793/b/solution.go
+++ b/src/codeforces/set1/set17/set179/set1793/b/solution.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 )
@@ -10,101 +9,34 @@ import (
 func main() {
 	reader := bufio.NewReader(os.Stdin)
 
-	tc := readNum(reader)
-
-	var buf bytes.Buffer
-
-	for tc > 0 {
-		tc--
-		x, y := readTwoNums(reader)
-		res := solve(x, y)
-		buf.WriteString(fmt.Sprintf("%d\n", len(res)))
-		for i := 0; i < len(res); i++ {
-			buf.WriteString(fmt.Sprintf("%d ", res[i]))
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, len(res))
+		for i := range res {
+			fmt.Fprint(writer, res[i], " ")
 		}
-		buf.WriteByte('\n')
+		fmt.Fprintln(writer)
 	}
-	fmt.Print(buf.String())
 }
 
-func readString(reader *bufio.Reader) string {
-	s, _ := reader.ReadString('\n')
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' || s[i] == '\r' {
-			return s[:i]
-		}
-	}
-	return s
-}
-
-func normalize(s string) string {
-
-	for i := len(s); i > 0; i-- {
-		if s[i-1] >= 'a' && s[i-1] <= 'z' {
-			return s[:i]
-		}
-	}
-	return ""
-}
-
-func readInt(bytes []byte, from int, val *int) int {
-	i := from
-	sign := 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	tmp := 0
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readNum(reader *bufio.Reader) (a int) {
-	bs, _ := reader.ReadBytes('\n')
-	readInt(bs, 0, &a)
-	return
-}
-
-func readTwoNums(reader *bufio.Reader) (a int, b int) {
-	res := readNNums(reader, 2)
-	a, b = res[0], res[1]
-	return
-}
-
-func readThreeNums(reader *bufio.Reader) (a int, b int, c int) {
-	res := readNNums(reader, 3)
-	a, b, c = res[0], res[1], res[2]
-	return
-}
-
-func readNNums(reader *bufio.Reader, n int) []int {
-	res := make([]int, n)
-	x := 0
-	bs, _ := reader.ReadBytes('\n')
-	for i := 0; i < n; i++ {
-		for x < len(bs) && (bs[x] < '0' || bs[x] > '9') && bs[x] != '-' {
-			x++
-		}
-		x = readInt(bs, x, &res[i])
-	}
-	return res
+func drive(reader *bufio.Reader) []int {
+	var x, y int
+	fmt.Fscan(reader, &x, &y)
+	return solve(x, y)
 }
 
 func solve(x int, y int) []int {
-	// 首先考虑怎么得到sum = x的最大值
-	//              和sum = y 的最小值
-	// 假设只有一个最小值 y，那么它两边需要 x - y - 1 个元素
-	// 2 * (x - y - 1) + 2 这个是最大值
+	// 一个最大值，一个最小值
 	n := 2 * (x - y)
 
 	res := make([]int, n)
 	z := y
 	delta := 1
-	for i := 0; i < n; i++ {
+	for i := range n {
 		res[i] = z
 		z += delta
 		if z > x {

--- a/src/codeforces/set2/set21/set216/set2167/e/problem.md
+++ b/src/codeforces/set2/set21/set216/set2167/e/problem.md
@@ -1,0 +1,92 @@
+# Problem
+
+khba has $n$ friends, each standing on a line at position $a_i$, and each of them is in the range $[0, x]$.
+
+They all want to come to him. One of his friends, Isamatdin, gave him $k$ teleports. Each friend will walk to the nearest teleport (choosing the shortest distance). Once a friend reaches a teleport, khba and the friend can instantly meet.
+
+But khba is so tired that he'll be sleeping while his friends are walking toward him. Now he wants to choose $k$ teleport positions so that their positions are distinct and lie within the range $[0, x]$, in order to maximize the time it takes for the first friend who reaches a teleport to reach it. Assume that friends move at the same speed.
+
+Since khba isn't good at calculations, you should output the $k$ chosen teleport positions.
+
+## Input
+
+Each test contains multiple test cases. The first line contains a single integer $t$ ($1 \le t \le 10^4$) — the number of test cases. The description of the test cases follows.
+
+The first line of each test case contains three integers $n$, $k$, and $x$ ($1 \le n, k \le 2 \cdot 10^5$, $k - 1 \le x \le 10^9$) — the number of friends, the number of teleports, and the range of possible positions for the teleports.
+
+The second line of each test case contains $n$ integers $a_1, a_2, \ldots, a_n$ ($0 \le a_i \le x$) — the positions of khba's friends.
+
+It is guaranteed that the sum of $n$ over all test cases does not exceed $2 \cdot 10^5$.
+
+It is guaranteed that the sum of $k$ over all test cases does not exceed $2 \cdot 10^5$.
+
+## Output
+
+For each test case, output a single line containing $k$ integers — the $k$ chosen teleport positions. The positions must be distinct and lie within the range $[0, x]$. The positions may be output in any order.
+
+If there are multiple optimal choices, output any of them.
+
+## Example
+
+### Input
+
+```
+10
+4 1 4
+1 0 2 4
+5 5 4
+0 1 2 3 4
+2 1 4
+4 0
+3 4 6
+2 4 3
+3 2 12
+6 12 0
+4 3 12
+8 12 0 4
+1 1 1000000000
+0
+1 1 1000000000
+1000000000
+3 4 9
+8 7 9
+3 4 9
+2 0 1
+```
+
+### Output
+
+```
+3
+0 1 2 3 4
+2
+0 1 5 6
+3 9
+2 6 10
+1000000000
+0
+0 1 2 3
+6 7 8 9
+```
+
+## Note
+
+**Sample 1.** Friends at positions $[1, 0, 2, 4]$. Chosen teleport position: $[3]$.
+
+Nearest teleport for each friend is in $3$, minimal times for friends are $[2, 3, 1, 1]$, respectively.
+
+**Sample 2.** Friends at positions $[0, 1, 2, 3, 4]$. Chosen teleport positions: $[0, 1, 2, 3, 4]$.
+
+Minimal times for friends are $[0, 0, 0, 0, 0]$, respectively.
+
+**Sample 3.** Friends at positions $[4, 0]$. Chosen teleport position: $[2]$.
+
+Minimal times for friends are $[2, 2]$, respectively.
+
+**Sample 4.** Friends at positions $[2, 4, 3]$. Chosen teleport positions: $[0, 1, 5, 6]$.
+
+Minimal times for friends are $[1, 1, 2]$, respectively.
+
+**Sample 5.** Friends at positions $[6, 12, 0]$. Chosen teleport positions: $[3, 9]$.
+
+Minimal times for friends are $[3, 3, 3]$, respectively.

--- a/src/codeforces/set2/set21/set216/set2167/e/solution.go
+++ b/src/codeforces/set2/set21/set216/set2167/e/solution.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		_, _, _, res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func drive(reader *bufio.Reader) (k int, x int, a []int, res []int) {
+	var n int
+	fmt.Fscan(reader, &n, &k, &x)
+	a = make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	slices.Sort(a)
+
+	res = solve(a, x, k)
+	return
+}
+
+const inf = 1 << 60
+
+func solve(a []int, x int, k int) []int {
+
+	n := len(a)
+	check := func(mid int) bool {
+		if mid == 0 {
+			return true
+		}
+		var cnt int
+		// 这个k个肯定是放在a[i], a[i+1]的中间
+		for i := 0; i < n; i++ {
+			if i == 0 {
+				// 看看前面可不可以放置
+				cnt += max(0, a[i]-mid+1)
+			}
+			if i+1 < n {
+				// i和i+1中间放置
+				l := a[i] + mid
+				r := a[i+1] - mid
+				cnt += max(0, r-l+1)
+			} else {
+				// i == n - 1
+				l := a[i] + mid
+				r := x
+				cnt += max(0, r-l+1)
+			}
+		}
+
+		return cnt >= k
+	}
+
+	var maxDist int
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			maxDist = a[i]
+		}
+		if i+1 < n {
+			maxDist = max(maxDist, a[i+1]-a[i])
+		} else {
+			maxDist = max(maxDist, x-a[i])
+		}
+	}
+
+	lo, hi := 0, maxDist+1
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if !check(mid) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	dist := hi - 1
+	var res []int
+	if dist > 0 {
+		add := func(l int, r int) {
+			for i := l; i <= r && len(res) < k; i++ {
+				res = append(res, i)
+			}
+		}
+		for i := 0; i < n; i++ {
+			if i == 0 {
+				add(0, a[i]-dist)
+			}
+			if i+1 < n {
+				add(a[i]+dist, a[i+1]-dist)
+			} else {
+				add(a[i]+dist, x)
+			}
+		}
+	} else {
+		for len(res) < k {
+			res = append(res, len(res))
+		}
+	}
+
+	return res[:k]
+}

--- a/src/codeforces/set2/set21/set216/set2167/e/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2167/e/solution_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	k, x, a, res := drive(reader)
+
+	if len(res) != k || res[len(res)-1] > x {
+		t.Fatalf("Sample expect %d, but got %d", k, len(res))
+	}
+
+	// a is sorted
+
+	play := func(res []int) int {
+		maxDist := inf
+		for i, j := 0, 0; i < len(res); i++ {
+			curPos := res[i]
+			for j < len(a) && a[j] <= curPos {
+				maxDist = min(maxDist, curPos-a[j])
+				j++
+			}
+			if j < len(a) {
+				maxDist = min(maxDist, a[j]-curPos)
+			}
+		}
+		return maxDist
+	}
+
+	w := play(expect)
+	v := play(res)
+
+	if w != v {
+		t.Fatalf("Sample result %v, expect %d, but got %d", res, w, v)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `4 1 4
+1 0 2 4`
+	expect := []int{3}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5 5 4
+0 1 2 3 4`
+	expect := []int{0, 1, 2, 3, 4}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `2 1 4
+4 0`
+	expect := []int{2}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `3 4 6
+2 4 3`
+	expect := []int{0, 1, 5, 6}
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `3 2 12
+6 12 0`
+	expect := []int{3, 9}
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `4 3 12
+8 12 0 4`
+	expect := []int{2, 6, 10}
+	runSample(t, s, expect)
+}
+
+func TestSample7(t *testing.T) {
+	s := `1 1 1000000000
+0`
+	expect := []int{1000000000}
+	runSample(t, s, expect)
+}
+
+func TestSample8(t *testing.T) {
+	s := `1 1 1000000000
+1000000000`
+	expect := []int{0}
+	runSample(t, s, expect)
+}
+
+func TestSample9(t *testing.T) {
+	s := `3 4 9
+8 7 9`
+	expect := []int{0, 1, 2, 3}
+	runSample(t, s, expect)
+}
+
+func TestSample10(t *testing.T) {
+	s := `3 4 9
+2 0 1`
+	expect := []int{6, 7, 8, 9}
+	runSample(t, s, expect)
+}

--- a/src/leetcode/set1000/set3000/set3800/set3880/p3889/solution.go
+++ b/src/leetcode/set1000/set3000/set3800/set3880/p3889/solution.go
@@ -1,0 +1,22 @@
+package p3889
+
+func mirrorFrequency(s string) int {
+	freq := make(map[byte]int)
+	for i := range s {
+		freq[s[i]]++
+	}
+	var res int
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	for i := range len(letters) / 2 {
+		res += abs(freq[letters[i]] - freq[letters[len(letters)-i-1]])
+	}
+	const nums = "0123456789"
+	for i := range len(nums) / 2 {
+		res += abs(freq[nums[i]] - freq[nums[len(nums)-i-1]])
+	}
+	return res
+}
+
+func abs(num int) int {
+	return max(num, -num)
+}

--- a/src/leetcode/set1000/set3000/set3800/set3890/p3890/solution.go
+++ b/src/leetcode/set1000/set3000/set3800/set3890/p3890/solution.go
@@ -1,0 +1,26 @@
+package p3890
+
+import "slices"
+
+func findGoodIntegers(n int) []int {
+	var cubes []int
+	for x := 1; x*x <= n/x; x++ {
+		cubes = append(cubes, x*x*x)
+	}
+	// len(x) <= 1000
+
+	freq := make(map[int]int)
+
+	var res []int
+	for i, x := range cubes {
+		for j := i; j < len(cubes) && x+cubes[j] <= n; j++ {
+			y := cubes[j]
+			freq[x+y]++
+			if freq[x+y] == 2 {
+				res = append(res, x+y)
+			}
+		}
+	}
+	slices.Sort(res)
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3800/set3890/p3891/solution.go
+++ b/src/leetcode/set1000/set3000/set3800/set3890/p3891/solution.go
@@ -1,0 +1,39 @@
+package p3891
+
+func minIncrease(nums []int) int64 {
+	n := len(nums)
+	play := func(s int) int {
+		var res int
+		for i := s; i+1 < n; i += 2 {
+			res += max(0, max(nums[i-1], nums[i+1])+1-nums[i])
+		}
+		return res
+	}
+
+	if n%2 == 1 {
+		return int64(play(1))
+	}
+
+	// 只在1,3,5,7
+	dp := make([]int, n)
+	for i := 1; i < n; i++ {
+		dp[i] = dp[i-1]
+		if i&1 == 1 && i < n-1 {
+			dp[i] += max(0, max(nums[i-1], nums[i+1])+1-nums[i])
+		}
+	}
+	res := dp[n-1]
+
+	var fp int
+	for i := n - 2; i >= 2; i-- {
+		if i&1 == 0 {
+			fp += max(0, max(nums[i-1], nums[i+1])+1-nums[i])
+			if i >= 3 {
+				res = min(res, dp[i-3]+fp)
+			}
+		}
+
+	}
+
+	return int64(min(res, fp))
+}

--- a/src/leetcode/set1000/set3000/set3800/set3890/p3891/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3800/set3890/p3891/solution_test.go
@@ -1,0 +1,22 @@
+package p3891
+
+import "testing"
+
+func runSample(t *testing.T, nums []int, expect int64) {
+	res := minIncrease(nums)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{2, 1, 1, 3}
+	expect := int64(2)
+	runSample(t, nums, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{20, 7, 6, 4, 23, 17}
+	expect := int64(2)
+	runSample(t, nums, expect)
+}

--- a/src/leetcode/set1000/set3000/set3800/set3890/p3892/solution.go
+++ b/src/leetcode/set1000/set3000/set3800/set3890/p3892/solution.go
@@ -1,0 +1,58 @@
+package p3892
+
+const inf = 1 << 60
+
+func minOperations(nums []int, k int) int {
+	if k == 0 {
+		return 0
+	}
+	n := len(nums)
+
+	if k > n/2 {
+		return -1
+	}
+
+	play := func(incFirst bool) int {
+		dp := make([][]int, k+1)
+		ndp := make([][]int, k+1)
+		for i := range k + 1 {
+			dp[i] = make([]int, 2)
+			ndp[i] = make([]int, 2)
+			for j := range 2 {
+				dp[i][j] = inf
+				ndp[i][j] = inf
+			}
+		}
+		dp[0][0] = 0
+		if incFirst {
+			dp[1][1] = max(0, max(nums[1], nums[n-1])+1-nums[0])
+		}
+
+		// dp[x][1] 表示到i为止，有x个peak，且第i个数是peak时
+		for i := 1; i < n; i++ {
+			for j := range k + 1 {
+				nj := min(k, j+1)
+
+				delta := max(0, max(nums[(i+1)%n], nums[i-1])+1-nums[i])
+				if i < n-1 || !incFirst {
+					ndp[nj][1] = min(ndp[nj][1], dp[j][0]+delta)
+				}
+				// 当前值不作为peak时
+				ndp[j][0] = min(ndp[j][0], dp[j][0], dp[j][1])
+			}
+			for j := range k + 1 {
+				for d := range 2 {
+					dp[j][d] = ndp[j][d]
+					ndp[j][d] = inf
+				}
+			}
+		}
+
+		if incFirst {
+			return dp[k][0]
+		}
+		return min(dp[k][0], dp[k][1])
+	}
+
+	return min(play(true), play(false))
+}

--- a/src/leetcode/set1000/set3000/set3800/set3890/p3892/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3800/set3890/p3892/solution_test.go
@@ -1,0 +1,45 @@
+package p3892
+
+import "testing"
+
+func runSample(t *testing.T, nums []int, k int, expect int) {
+	res := minOperations(nums, k)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{2, 1, 2}
+	k := 1
+	expect := 1
+	runSample(t, nums, k, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{4, 5, 3, 6}
+	k := 2
+	expect := 0
+	runSample(t, nums, k, expect)
+}
+
+func TestSample3(t *testing.T) {
+	nums := []int{3, 7, 3}
+	k := 2
+	expect := -1
+	runSample(t, nums, k, expect)
+}
+
+func TestSample4(t *testing.T) {
+	nums := []int{1, -4}
+	k := 0
+	expect := 0
+	runSample(t, nums, k, expect)
+}
+
+func TestSample5(t *testing.T) {
+	nums := []int{23, 10, -14, -23, 1}
+	k := 2
+	expect := 25
+	runSample(t, nums, k, expect)
+}


### PR DESCRIPTION
## Summary
- Add Codeforces packages 24D, 1089E/F, 1110D, 2167E with statements, solutions, and tests where applicable.
- Add LeetCode 3889, 3890, 3891, 3892 solutions (tests for 3891/3892).
- Fix 1111B initial average calculation and update set1793B solution.

## Test plan
- [x] `go test` on set024/d, set1089/f, set1110/d, set2167/e, p3891, p3892

Made with [Cursor](https://cursor.com)