### PR TITLE
Add Codeforces set2163-set2166 solutions and docs

### DIFF
--- a/src/codeforces/set1/set18/set186/set1862/f/solution.go
+++ b/src/codeforces/set1/set18/set186/set1862/f/solution.go
@@ -2,275 +2,58 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 )
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
 
-	tc := readNum(reader)
-
-	var buf bytes.Buffer
-
-	for tc > 0 {
-		tc--
-		w, f := readTwoNums(reader)
-		n := readNum(reader)
-		s := readNNums(reader, n)
-		res := solve(w, f, s)
-		buf.WriteString(fmt.Sprintf("%d\n", res))
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
 	}
-
-	fmt.Print(buf.String())
 }
 
-func readString(reader *bufio.Reader) string {
-	s, _ := reader.ReadString('\n')
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' || s[i] == '\r' {
-			return s[:i]
-		}
-	}
-	return s
-}
-
-func readNInt64s(reader *bufio.Reader, n int) []int64 {
-	res := make([]int64, n)
-	s, _ := reader.ReadBytes('\n')
-
-	var pos int
-
+func drive(reader *bufio.Reader) int {
+	var w, f, n int
+	fmt.Fscan(reader, &w, &f, &n)
+	s := make([]int, n)
 	for i := 0; i < n; i++ {
-		pos = readInt64(s, pos, &res[i]) + 1
+		fmt.Fscan(reader, &s[i])
 	}
-
-	return res
-}
-
-func readInt64(bytes []byte, from int, val *int64) int {
-	i := from
-	var sign int64 = 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	var tmp int64
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int64(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readInt(bytes []byte, from int, val *int) int {
-	i := from
-	sign := 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	tmp := 0
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readNum(reader *bufio.Reader) (a int) {
-	bs, _ := reader.ReadBytes('\n')
-	readInt(bs, 0, &a)
-	return
-}
-
-func readTwoNums(reader *bufio.Reader) (a int, b int) {
-	res := readNNums(reader, 2)
-	a, b = res[0], res[1]
-	return
-}
-
-func readThreeNums(reader *bufio.Reader) (a int, b int, c int) {
-	res := readNNums(reader, 3)
-	a, b, c = res[0], res[1], res[2]
-	return
-}
-
-func readNNums(reader *bufio.Reader, n int) []int {
-	res := make([]int, n)
-	x := 0
-	bs, _ := reader.ReadBytes('\n')
-	for i := 0; i < n; i++ {
-		for x < len(bs) && (bs[x] < '0' || bs[x] > '9') && bs[x] != '-' {
-			x++
-		}
-		x = readInt(bs, x, &res[i])
-	}
-	return res
+	return solve(w, f, s)
 }
 
 func solve(w int, f int, s []int) int {
-	n := len(s)
+	// n := len(s)
 	var sum int
 	for _, x := range s {
 		sum += x
 	}
 
-	dp := NewBitSet(sum + 1)
-	fp := NewBitSet(sum + 1)
-	check := func(t int) bool {
-		// 是否能够在t时间内消灭所有的monsters
-		W := w * t
-		F := f * t
-
-		if W >= sum || F >= sum {
-			// 只使用一种魔法就能消灭所有的monsters
-			return true
-		}
-
-		dp.Set(0)
-
-		for i := 0; i < n; i++ {
-			x := s[i]
-			dp.CopyTo(fp)
-			fp.LeftShift(x)
-			dp.Union(fp)
-		}
-		var ok bool
-		for x := sum - F; x <= W; x++ {
-			if dp.IsSet(x) {
-				ok = true
-				break
-			}
-		}
-
-		dp.Reset()
-		fp.Reset()
-		return ok
-	}
-
-	r := sum/max(w, f) + 1
-	var l int
-
-	for l < r {
-		mid := (l + r) >> 1
-		if check(mid) {
-			r = mid
-		} else {
-			l = mid + 1
-		}
-	}
-	return r
-}
-
-func max(a, b int) int {
-	if a >= b {
-		return a
-	}
-	return b
-}
-
-type BitSet struct {
-	sz  int
-	arr []uint64
-}
-
-func NewBitSet(n int) *BitSet {
-	sz := (n + 63) / 64
-	arr := make([]uint64, sz)
-	return &BitSet{sz, arr}
-}
-
-func (bs *BitSet) Set(p int) {
-	i, j := p/64, p%64
-	i = bs.sz - 1 - i
-	bs.arr[i] |= 1 << uint64(j)
-}
-
-func (bs *BitSet) IsSet(p int) bool {
-	i, j := p/64, p%64
-	i = bs.sz - 1 - i
-	return (bs.arr[i]>>uint64(j))&1 == 1
-}
-
-func (bs *BitSet) Count() int {
-	var res int
-	for i := 0; i < bs.sz; i++ {
-		res += countDigit(bs.arr[i])
-	}
-	return res
-}
-
-func countDigit(num uint64) int {
-	var res int
-	if (num>>63)&1 == 1 {
-		res++
-	}
-	tmp := int64(num & ((1 << 63) - 1))
-
-	for tmp > 0 {
-		res++
-		tmp -= tmp & -tmp
-	}
-	return res
-}
-
-func (bs *BitSet) LeftShift(p int) {
-	i, j := p/64, p%64
-	if j == 0 {
-		for u := 0; u+i < bs.sz; u++ {
-			bs.arr[u] = bs.arr[u+i]
-		}
-	} else {
-		for u := 0; u+i < bs.sz; u++ {
-			v := u + i
-			bs.arr[u] = bs.arr[v] << uint64(j)
-			if v+1 < bs.sz {
-				bs.arr[u] |= bs.arr[v+1] >> uint64(64-j)
+	dp := make([]bool, sum+1)
+	dp[0] = true
+	sum = 0
+	for _, v := range s {
+		sum += v
+		for w := sum; w >= v; w-- {
+			if dp[w-v] {
+				dp[w] = true
 			}
 		}
 	}
-	for u := bs.sz - i; u < bs.sz; u++ {
-		bs.arr[u] = 0
-	}
-}
 
-func (bs *BitSet) RightShift(p int) {
-	i, j := p/64, p%64
-	if j == 0 {
-		for u := bs.sz - 1; u-i >= 0; u-- {
-			bs.arr[u] = bs.arr[u-i]
-		}
-	} else {
-		for u := bs.sz - 1; u-i >= 0; u-- {
-			v := u - i
-			bs.arr[u] = bs.arr[v] >> uint64(j)
-			if v-1 >= 0 {
-				bs.arr[u] |= bs.arr[v-1] << uint64(64-j)
-			}
+	best := (sum + w - 1) / w
+
+	for v := range sum + 1 {
+		if dp[v] {
+			best = min(best, max((v+w-1)/w, (sum-v+f-1)/f))
 		}
 	}
-	for u := i - 1; u >= 0; u-- {
-		bs.arr[u] = 0
-	}
-}
 
-func (bs *BitSet) CopyTo(that *BitSet) *BitSet {
-	copy(that.arr, bs.arr)
-	return that
-}
-
-func (this *BitSet) Union(that *BitSet) {
-	for i := 0; i < len(this.arr); i++ {
-		this.arr[i] |= that.arr[i]
-	}
-}
-
-func (this *BitSet) Reset() {
-	for i := 0; i < len(this.arr); i++ {
-		this.arr[i] = 0
-	}
+	return best
 }

--- a/src/codeforces/set2/set21/set216/set2163/c/problem.md
+++ b/src/codeforces/set2/set21/set216/set2163/c/problem.md
@@ -1,0 +1,78 @@
+# Statement
+
+You are given a grid `a` of **2** rows and **`n`** columns, where every cell has a value in **`1 .. 2n`**.
+
+For integers `(l, r)` with `1 <= l <= r <= 2n`, define **`f(l, r)`** as a **binary** grid `b` of 2 rows and `n` columns such that:
+
+- `b[i][j] = 1` if and only if `l <= a[i][j] <= r`,
+- otherwise `b[i][j] = 0`.
+
+Cell `(i, j)` is **`i`** rows from the top and **`j`** columns from the left.
+
+Count the number of pairs **`(l, r)`** with `1 <= l <= r <= 2n` such that in **`f(l, r)`** there exists a **down-right path** of adjacent cells with value **1** from **`(1, 1)`** to **`(2, n)`**.
+
+---
+
+**Binary grid.** A grid is binary if and only if every cell is **0** or **1**.
+
+**Down-right path.** A sequence of cells `(c1, c2, ...)` such that for each `k > 1`, cell `ck` shares either **its top side** or **its left side** with **some side of** `c(k-1)`. Equivalently, each step goes **one cell down** or **one cell right** (from `(1,1)` toward `(2,n)` in a 2×`n` grid).
+
+---
+
+## Input
+
+Each test contains multiple test cases. The first line contains **`t`** (`1 <= t <= 10^4`).
+
+For each test case:
+
+- Line 1: integer **`n`** (`2 <= n <= 2 * 10^5`) — number of columns.
+- Line 2: **`n`** integers `a[1][1], ..., a[1][n]` (`1 <= a[1][i] <= 2n`) — first row.
+- Line 3: **`n`** integers `a[2][1], ..., a[2][n]` (`1 <= a[2][i] <= 2n`) — second row.
+
+The sum of **`n`** over all test cases does not exceed **`2 * 10^5`**.
+
+## Output
+
+For each test case, print one integer: the number of pairs **`(l, r)`** with `1 <= l <= r <= 2n` such that **`f(l, r)`** admits a down-right path of **1**-cells from **`(1, 1)`** to **`(2, n)`**.
+
+## Example
+
+### Input
+
+```text
+5
+2
+1 3
+3 1
+3
+1 2 3
+3 2 1
+4
+1 5 5 5
+5 3 1 2
+4
+8 8 8 8
+8 8 8 8
+6
+6 6 5 7 9 12
+1 4 2 8 5 6
+```
+
+### Output
+
+```text
+2
+5
+4
+8
+25
+```
+
+### ideas
+1. 也就是说始终要存在一条边，从左上到右下的路径
+2. 假设在第i列转向到下面一行，那么可以知道这个时候，需要cover的所有的数字的范围
+3. 假设这个时候的最小值是a，最大值是b, 那么所有l <= a, b <= r的pair都可以满足条件
+4. 那么这样子可以得到n对(a, b), 从而对它们进行排序；
+5. 然后对这些pair进行处理，如果pair 1包含pair 2， 那么可以直接舍弃pair1, 
+6. 因为满足1的条件，也满足了2的条件，反过来不成立
+7. 这样子，就得到了一些相交但是不包含的区间; 处理逻辑是一样的

--- a/src/codeforces/set2/set21/set216/set2163/c/solution.go
+++ b/src/codeforces/set2/set21/set216/set2163/c/solution.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"cmp"
+	"container/heap"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([][]int, 2)
+	for i := range 2 {
+		a[i] = make([]int, n)
+		for j := range n {
+			fmt.Fscan(reader, &a[i][j])
+		}
+	}
+	return solve(a)
+}
+
+func solve(a [][]int) int {
+	n := len(a[0])
+	pref := make([][]int, n)
+	for i := range n {
+		pref[i] = make([]int, 2)
+		pref[i][0] = a[0][i]
+		pref[i][1] = a[0][i]
+		if i > 0 {
+			pref[i][0] = min(a[0][i], pref[i-1][0])
+			pref[i][1] = max(a[0][i], pref[i-1][1])
+		}
+	}
+
+	suf := make([][]int, n)
+	for i := n - 1; i >= 0; i-- {
+		suf[i] = make([]int, 2)
+		suf[i][0] = a[1][i]
+		suf[i][1] = a[1][i]
+		if i < n-1 {
+			suf[i][0] = min(a[1][i], suf[i+1][0])
+			suf[i][1] = max(a[1][i], suf[i+1][1])
+		}
+	}
+
+	var arr [][]int
+
+	for i := range n {
+		// 如果在i处往下
+		lo := min(pref[i][0], suf[i][0])
+		hi := max(pref[i][1], suf[i][1])
+		arr = append(arr, []int{lo, hi})
+	}
+
+	close := make([][]int, 2*n+1)
+	for i, cur := range arr {
+		hi := cur[1]
+		close[hi] = append(close[hi], i)
+	}
+	var active IntHeap
+
+	marked := make([]bool, len(arr))
+	for i := range 2*n + 1 {
+		for _, j := range close[i] {
+			lo := arr[j][0]
+			if len(active) > 0 && active[0] >= lo {
+				continue
+			}
+			heap.Push(&active, lo)
+			marked[j] = true
+		}
+	}
+	var markedArr [][]int
+	for i, cur := range arr {
+		if marked[i] {
+			markedArr = append(markedArr, cur)
+		}
+	}
+	slices.SortFunc(markedArr, func(a, b []int) int {
+		return cmp.Or(a[0]-b[0], a[1]-b[1])
+	})
+	var res int
+	for i := range len(markedArr) {
+		l := markedArr[i][0]
+		r := markedArr[i][1]
+		nr := 2*n + 1
+		if i+1 < len(markedArr) {
+			nr = markedArr[i+1][1]
+		}
+		res += l * (nr - r)
+	}
+
+	return res
+}
+
+type IntHeap []int
+
+func (h IntHeap) Len() int           { return len(h) }
+func (h IntHeap) Less(i, j int) bool { return h[i] > h[j] }
+func (h IntHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *IntHeap) Push(x any) {
+	*h = append(*h, x.(int))
+}
+
+func (h *IntHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/src/codeforces/set2/set21/set216/set2163/c/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2163/c/solution_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `2
+1 3
+3 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3
+1 2 3
+3 2 1
+`
+	expect := 5
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `4
+1 5 5 5
+5 3 1 2
+`
+	expect := 4
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `4
+8 8 8 8
+8 8 8 8
+`
+	expect := 8
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `6
+6 6 5 7 9 12
+1 4 2 8 5 6
+`
+	expect := 25
+	runSample(t, s, expect)
+}
+

--- a/src/codeforces/set2/set21/set216/set2164/d/problem.md
+++ b/src/codeforces/set2/set21/set216/set2164/d/problem.md
@@ -1,0 +1,126 @@
+Given two strings `s` and `t` of length `n`, you aim to transform `s` into `t` through a series of the following operations:
+
+- Construct a new string `s'` of length `n`, where `s'1 = s1`.
+- For each `1 < i <= n`, `s'i` can be either `si` or `s(i-1)`.
+- Then replace `s` with `s'`.
+
+Your task is to achieve this transformation using the minimum number of operations. You also need to output the solution by printing the constructed string `s'` after each operation. If the transformation cannot be achieved in less than or equal to `kmax` operations, output `-1`.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 <= t <= 10^4`). The description of the test cases follows.
+
+The first line of each test case contains two integers `n`, `kmax` (`1 <= n * kmax <= 10^6`) — the length of two strings and the maximum number of operations that can be used.
+
+The second line of each test case contains one string `s` of length `n`.
+
+The third line of each test case contains one string `t` of length `n`.
+
+It is guaranteed that the sum of `n * kmax` over all test cases does not exceed `10^6`.
+
+It is guaranteed that both `s` and `t` consist of lowercase Latin letters.
+
+## Output
+
+For each test case:
+
+- If you cannot achieve the transformation in less than or equal to `kmax` operations, simply output `-1` in one line.
+- Otherwise, on the first line, output one integer `k <= kmax` — the minimum number of operations. Then `k` lines follow, each line contains one string of length `n` — the string after each operation.
+- If there are multiple solutions, output any.
+
+## Example
+
+### Input
+
+```text
+7
+4 1
+abcd
+aabd
+2 2
+ab
+ab
+5 3
+abcde
+abbcc
+9 1
+egcnyeluw
+eegccyelw
+10 3
+vzvylxxmsy
+vvvvvllxxx
+4 6
+acba
+aaac
+5 7
+acabb
+aaaca
+```
+
+### Output
+
+```text
+1
+aabd
+0
+2
+abbcd
+abbcc
+-1
+3
+vvzvylxxms
+vvvzvllxxm
+vvvvvllxxx
+2
+aacb
+aaac
+2
+aacab
+aaaca
+```
+
+## Note
+
+In the first test case, obviously `s` can be transformed to `t` in one operation.
+
+In the second test case, initially `s = t`, so no operation is needed.
+
+In the fourth test case, although `s` can be transformed to `t` in two operations, `kmax = 1`, so the answer is `-1`.
+
+### ideas
+1. s[1]不能被改变（所以 s[1] != t[1] => -1)
+2. 考虑s[n], t[n], 如果s[n] != t[n], 那么必须找到一个s[i] = t[n], 通过n-i次操作将s[n]编程s[i]
+3. 如果n-i > kmx => -1
+4. 同时 i到n中间的都需要s[i]
+
+### solution summary
+
+Scan positions from right to left and greedily fix `t[i]`.
+
+Key observations:
+
+1. `s[0]` never changes, so if `s[0] != t[0]`, answer is impossible.
+2. In one operation, each position can only copy from itself or left neighbor, so characters only propagate to the right.
+3. To make `i` become `t[i]`, we must pick some `i1 <= i` with current `s[i1] = t[i]`, then shift that value right step by step; this needs exactly `i - i1` operations.
+
+Greedy construction:
+
+- Maintain `buf` as current string state during planning.
+- Maintain `pos[c]`: indices where character `c` currently appears in `buf` (as stacks, rightmost accessible index at the end).
+- For `i = n-1 .. 1`:
+  - Remove index `i` from `pos[buf[i]]` (this position is being finalized).
+  - If `buf[i] == t[i]`, continue.
+  - Otherwise choose `i1 = rightmost index in pos[t[i]]`.
+    - If not found, impossible.
+    - If `i - i1 > kmax`, impossible.
+  - Record that for every distance `d = 1..i-i1`, position `i1+d` must copy from left in operation `d`.
+  - Simulate these shifts on `buf` and update `pos` so later positions use the latest state.
+
+Let `k` be the maximum needed distance over all fixed positions. This `k` is minimal, because each fixed position requiring distance `d` enforces at least `d` operations globally.
+
+Finally, replay operations `1..k` on the original `s` using recorded position lists to output each intermediate string.
+
+Complexity:
+
+- Each index is pushed/popped/updated `O(1)` amortized in the right-to-left process.
+- Total time `O(n)`, memory `O(n)` per test case.

--- a/src/codeforces/set2/set21/set216/set2164/d/solution.go
+++ b/src/codeforces/set2/set21/set216/set2164/d/solution.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	tc := readNums(reader)[0]
+	for range tc {
+		_, _, ok, res := drive(reader)
+		if !ok {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		fmt.Fprintln(writer, len(res))
+		for _, s := range res {
+			fmt.Fprintln(writer, s)
+		}
+	}
+}
+
+func readString(reader *bufio.Reader) string {
+	s, _ := reader.ReadString('\n')
+	return strings.TrimSpace(s)
+}
+
+func readNums(reader *bufio.Reader) []int {
+	s := readString(reader)
+	ss := strings.Split(s, " ")
+	res := make([]int, len(ss))
+	for i := range res {
+		res[i], _ = strconv.Atoi(ss[i])
+	}
+	return res
+}
+
+func drive(reader *bufio.Reader) (s string, t string, ok bool, res []string) {
+	nums := readNums(reader)
+	k := nums[1]
+	s = readString(reader)
+	t = readString(reader)
+	ok, res = solve(s, t, k)
+	return
+}
+
+func solve(s string, t string, kmx int) (ok bool, res []string) {
+	if s[0] != t[0] {
+		return false, nil
+	}
+	n := len(s)
+	pos := make([][]int, 26)
+	for i := range n {
+		x := int(s[i] - 'a')
+		pos[x] = append(pos[x], i)
+	}
+
+	buf := []byte(s)
+	todo := make([][]int, kmx+1)
+
+	var k int
+
+	for i := n - 1; i > 0; i-- {
+		x := int(buf[i] - 'a')
+		pos[x] = pos[x][:len(pos[x])-1]
+		if buf[i] == t[i] {
+			continue
+		}
+		// buf[i] != t[i]
+		w := int(t[i] - 'a')
+		if len(pos[w]) == 0 {
+			return false, nil
+		}
+		i1 := pos[w][len(pos[w])-1]
+		if i-i1 > kmx {
+			return false, nil
+		}
+		k = max(k, i-i1)
+
+		for j := i - 1; j > i1; j-- {
+			x := int(buf[j] - 'a')
+			pos[x] = pos[x][:len(pos[x])-1]
+		}
+
+		for j := i1 + 1; j <= i; j++ {
+			todo[j-i1] = append(todo[j-i1], j)
+			buf[j] = buf[j-1]
+			x := int(buf[j] - 'a')
+			if j < i {
+				pos[x] = append(pos[x], j)
+			}
+		}
+	}
+
+	buf = []byte(s)
+	for i := 1; i <= k; i++ {
+		// todo is in descending order
+		for _, j := range todo[i] {
+			buf[j] = buf[j-1]
+		}
+		res = append(res, string(buf))
+	}
+
+	return true, res
+}

--- a/src/codeforces/set2/set21/set216/set2164/d/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2164/d/solution_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, input string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(input))
+	s, x, ok, res := drive(reader)
+
+	if expect < 0 {
+		if ok {
+			t.Fatalf("Sample expect %d, but got %v", expect, res)
+		}
+		return
+	}
+	if !ok {
+		t.Fatalf("Sample expect %d, but got %v", expect, res)
+	}
+	if len(res) != expect {
+		t.Fatalf("Sample expect %d, but got %v", expect, res)
+	}
+	buf := s
+
+	n := len(buf)
+	for _, cur := range res {
+		for i := 1; i < n; i++ {
+			if cur[i] != buf[i-1] && cur[i] != buf[i] {
+				t.Fatalf("Sample result %v, not valid", res)
+			}
+		}
+		buf = cur
+	}
+
+	if buf != x {
+		t.Fatalf("Sample expect %s, but got %s", x, buf)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `4 1
+abcd
+aabd`
+	expect := 1
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `2 2
+ab
+ab`
+	expect := 0
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5 3
+abcde
+abbcc`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `9 1
+egcnyeluw
+eegccyelw`
+	expect := -1
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `10 3
+vzvylxxmsy
+vvvvvllxxx`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `4 6
+acba
+aaac`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample7(t *testing.T) {
+	s := `5 7
+acabb
+aaaca`
+	expect := 2
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set216/set2164/e/problem.md
+++ b/src/codeforces/set2/set21/set216/set2164/e/problem.md
@@ -1,0 +1,259 @@
+# Statement
+
+You are on an undirected connected graph of `n` vertices and `m` weighted edges.  
+The edges are indexed from `1` to `m`. The `i`-th edge connects vertices `ui` and `vi`, and has weight `wi`.
+
+You decided to take a wonderful journey around the graph.
+
+Suppose you are currently at vertex `x`. You can do the following operations any number of times:
+
+1. Mark an edge connecting `x` and `y`, take photos along the edge, and move to `y`.  
+   This costs exactly the edge weight.
+2. Transfer by train to another arbitrary vertex `z != x`.  
+   You may choose any path `x ⇝ z` (not necessarily simple).  
+   If the path uses edges with indices `e1, e2, ..., ek`, then the transfer cost is:
+   `w[max(e1, e2, ..., ek)]`.
+
+Formally, there exists a vertex sequence `p1, p2, ..., p(k+1)` such that:
+
+- `x = p1`
+- `z = p(k+1)`
+- for each `i in [1, k]`, edge `ei` connects `pi` and `p(i+1)`
+
+You are now at vertex `1`, and you need to mark every edge at least once and return to vertex `1`.  
+Calculate the minimum total cost.
+
+Please note: transfer cost is **not** the maximum edge weight on the path, and **not** the maximum index itself; it is the **weight of the edge whose index is maximal** on that path.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `T` (`1 <= T <= 10^4`).
+
+For each test case:
+
+- The first line contains two integers `n` and `m` (`1 <= n <= 10^6`, `0 <= m <= 10^6`).
+- Each of the next `m` lines contains `ui, vi, wi` (`1 <= ui, vi <= n`, `1 <= wi <= 10^9`), describing edge `i`.
+
+It is guaranteed that:
+
+- the graph is connected,
+- the graph may contain self-loops and multiple edges,
+- the sums of `n` and `m` over all test cases do not exceed `10^6` each.
+
+## Output
+
+For each test case, output one integer — the minimum cost.
+
+## Example
+
+### Input
+
+```text
+5
+5 6
+2 4 15
+2 5 4
+1 3 6
+2 3 9
+1 2 10
+3 4 7
+4 3
+1 2 3
+1 3 2
+1 4 1
+2 3
+1 2 1
+2 1 3
+1 1 4
+6 6
+2 3 10
+1 3 10
+5 6 10
+6 6 1
+4 5 10
+3 4 10
+5 5
+1 2 4
+5 1 5
+4 3 6
+2 4 10
+1 4 7
+```
+
+### Output
+
+```text
+58
+8
+8
+71
+43
+```
+
+## Note
+
+Visualizer link
+
+Let `u --e--> v` denote going from vertex `u` to vertex `v` using edge `e`.
+
+In the first test case, one possible solution is:
+
+- Initially at vertex `1`.
+- Mark edge `3` and move to vertex `3`, cost `6`.
+- Mark edge `6` and move to vertex `4`, cost `7`.
+- Mark edge `1` and move to vertex `2`, cost `15`.
+- Mark edge `4` and move to vertex `3`, cost `9`.
+- Transfer to vertex `5` using path `3 --6--> 4 --1--> 2 --2--> 5`, cost `7`  
+  (max edge index on path is `6`, so cost is `w6 = 7`).
+- Mark edge `2` and move to vertex `2`, cost `4`.
+- Mark edge `5` and move to vertex `1`, cost `10`.
+
+Total cost: `6 + 7 + 15 + 9 + 7 + 4 + 10 = 58`.
+
+In the second test case, one possible solution is:
+
+- Mark edge `1` and move to vertex `2`, cost `3`.
+- Transfer to vertex `3` by path `2 --1--> 1 --3--> 4 --3--> 1 --2--> 3`, cost `1`.  
+  (The transfer path is allowed to be non-simple.)
+- Mark edge `2` and move to vertex `1`, cost `2`.
+- Mark edge `3` and move to vertex `4`, cost `1`.
+- Transfer to vertex `1` by path `4 --3--> 1`, cost `1`.
+
+## Algorithm
+
+Let the answer be:
+
+- the sum of all edge weights, because every edge must be marked at least once;
+- plus the minimum extra cost needed to fix parity, so that the whole route can start at `1`, end at `1`, and use marked edges as an Euler tour with some transfers inserted.
+
+So the real task is: how do we pair the odd-degree vertices using the special transfer cost?
+
+### 1. Why only odd-degree vertices matter
+
+If we only look at marked-edge traversals, every time we enter a vertex through marked edges we must also leave it through marked edges, except for route endpoints. Since the route starts and ends at vertex `1`, after adding transfers every vertex must effectively have even degree in the marked-edge multiset.
+
+That means:
+
+- vertices with even degree need nothing;
+- vertices with odd degree must be matched by transfers.
+
+So we only need to compute the cheapest way to pair odd-degree vertices.
+
+### 2. Transfer cost between two vertices
+
+For a transfer from `x` to `y`, we may choose any path, and the price is:
+
+`weight of the edge with maximum index on that path`.
+
+This means the path cost is determined by edge index order, not by edge weight.
+
+A key reformulation is:
+
+- if we process edges in index order `1..m`,
+- then the first moment when `x` and `y` become connected
+- determines the transfer cost candidate;
+- however, later edges inside the same connected component may reduce that cost further, because a later edge may have smaller weight.
+
+So a normal MST is not enough. We need a structure that preserves how connected components evolve in index order.
+
+### 3. Component-evolution tree
+
+Process edges in original order. Maintain DSU connected components.
+
+Create a tree node for every original vertex and for every edge.
+
+When processing edge `(u, v, w)`:
+
+- if `u` and `v` are in different DSU components, create a new internal node with label `w`, and connect it to the current roots of those two component trees; then merge the DSU components, and the new node becomes the root of the merged component;
+- if `u` and `v` are already in the same DSU component, create a new unary node with label `w` whose child is the current component root; this records that a later edge appeared inside the component and may lower future transfer cost.
+
+After all edges are processed, each DSU component is represented by one rooted tree. Since the graph is connected, we get one final root.
+
+Interpretation:
+
+- every node represents some connected subgraph that already exists after processing a prefix of edges;
+- its label is the weight of the edge that created this state;
+- for any two vertices, the first tree node whose subtree contains both vertices represents the earliest component containing both;
+- the best transfer cost inside that component is the minimum label on the path from that node upward through unary wrappers created later.
+
+### 4. Best transfer cost for each merge node
+
+Run one DFS from the final root.
+
+Define `best[u]` as the minimum label on the path from the global root down to `u`.
+
+Then for every binary merge node `u`, `best[u]` is exactly the minimum transfer cost that can be used to connect one odd vertex from its left child subtree and one odd vertex from its right child subtree.
+
+Why?
+
+- the two odd vertices become connectable when their components first merge at `u`;
+- after that, any later unary wrappers above `u` correspond to extra edges added inside the same larger component, which may reduce the transfer cost;
+- taking the minimum label on that ancestor chain captures the cheapest possible transfer after they are already in one component.
+
+### 5. Tree DP for pairing odd vertices
+
+Now do a bottom-up DP on the component tree.
+
+Let `unmatched[u]` be the number of odd-degree vertices in the subtree of `u` that are still unpaired after processing everything inside this subtree as cheaply as possible.
+
+Transitions:
+
+- for an original vertex node: `unmatched[u] = degree(u) mod 2`;
+- for a unary node: `unmatched[u] = unmatched[child]`;
+- for a binary merge node with children `L` and `R`:
+  - let `cnt = unmatched[L] + unmatched[R]`;
+  - inside this merged component, we can pair as many cross-subtree odd vertices as possible;
+  - each such pair costs `best[u]`;
+  - number of pairs is `cnt / 2`;
+  - so add `(cnt / 2) * best[u]` to the answer;
+  - keep `unmatched[u] = cnt mod 2`.
+
+This greedy pairing is optimal because `best[u]` is the first cost level where odd vertices from the two child components can interact. Any odd vertices not paired here must go upward and can only be paired with cost no smaller than what is available above.
+
+In a connected graph, the total number of odd-degree vertices is even, so the final root leaves `0` unmatched.
+
+### 6. Full procedure
+
+1. Add all edge weights to the answer.
+2. Compute parity of each vertex degree, ignoring self-loops for parity because they contribute `2` to degree.
+3. Build the component-evolution tree with DSU in original edge order.
+4. DFS the tree to compute `best[u]`.
+5. Run bottom-up DP to add the minimum extra transfer cost.
+
+### 7. Complexity
+
+- DSU construction: `O(m alpha(n))`
+- tree traversal and DP: `O(n + m)`
+- memory: `O(n + m)`
+
+This fits the constraint that total `n` and total `m` over all test cases are at most `10^6`.
+
+## Official Editorial 
+
+Since every edge must be marked at least once, a baseline cost is the **sum of all edge weights** (add every `wi` for `i = 1 .. m`).
+
+- If the graph is **Eulerian** (every vertex has even degree), that sum alone suffices: walk an Euler tour that uses each edge once.
+- Otherwise, think of adding **virtual edges** whose cost is the **minimum train-transfer cost** between their endpoints. Only **odd-degree** vertices need pairing; optimally you add **one** virtual edge per matched pair.
+
+### Transfer cost and reconstruction tree
+
+To compute transfer costs, build a **reconstruction tree** `T` of `G` by inserting real edges in index order `1 .. m` (Kruskal / DSU style).
+
+For a transfer from `u` to `v`, let `o = LCA(u, v)` in `T`. The edge with **maximum index** on any `u`–`v` path in `G` corresponds to `o` or one of its **ancestors** in `T` (standard reconstruction-tree property).
+
+For each internal node `i` of `T` (nodes that correspond to edges of `G`), precompute:
+
+- `f[i] =` minimum edge weight among **`i` and all ancestors of `i`** (on the path to the root).
+
+Then `f[i] <= f[parent(i)]`, so when two odd vertices first share a subtree rooted at internal node `p`, it is optimal to pair them **as early as possible** using cost **`f[p]`**.
+
+### Greedy DFS matching
+
+DFS the reconstruction tree from the root. For each node `x`, for each child `y`, recurse and track whether an **unmatched leaf** (original graph vertex) of **odd degree** remains in `y`’s subtree. Whenever two such leaves can be paired at `x`, pay **`f[x]`** immediately. When finishing `x`, at most **one** odd leaf in `x`’s subtree stays unmatched and is passed upward.
+
+This greedy pairing is optimal with the above `f[·]`.
+
+### Complexity (editorial)
+
+- **Time:** `O(m * α(n))` for DSU while building the tree, plus linear tree work.
+- **Space:** `O(n + m)` for the tree and auxiliary arrays (implementation-dependent; the original note mentions `O(n)` in a looser sense).

--- a/src/codeforces/set2/set21/set216/set2164/e/solution.go
+++ b/src/codeforces/set2/set21/set216/set2164/e/solution.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const inf int = 1 << 60
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	edges := make([][]int, m)
+	for i := range m {
+		edges[i] = make([]int, 3)
+		fmt.Fscan(reader, &edges[i][0], &edges[i][1], &edges[i][2])
+	}
+
+	return solve(n, edges)
+}
+
+func solve(n int, edges [][]int) int {
+	dsu := make([]int, n+len(edges))
+	for i := range dsu {
+		dsu[i] = i
+	}
+
+	var find func(x int) int
+	find = func(x int) int {
+		if dsu[x] != x {
+			dsu[x] = find(dsu[x])
+		}
+		return dsu[x]
+	}
+
+	adj := make([][]int, n+len(edges))
+	val := make([]int, n+len(edges))
+	var tot int
+	// process edges sequentially
+	id := n
+	deg := make([]int, n)
+	for _, e := range edges {
+		u, v, w := e[0]-1, e[1]-1, e[2]
+		deg[u]++
+		deg[v]++
+		tot += w
+		ru := find(u)
+		rv := find(v)
+		val[id] = w
+		if ru != rv {
+			// Merge two different components: create one new internal node
+			// whose children are the current roots of both components.
+			adj[id] = append(adj[id], ru)
+			adj[id] = append(adj[id], rv)
+			dsu[ru] = id
+			dsu[rv] = id
+		} else {
+			// Edge inside one component: create a unary wrapper, not two copies
+			// of the same child. This preserves the editorial's "ancestor can
+			// lower the transfer cost" behavior.
+			adj[id] = append(adj[id], ru)
+			dsu[ru] = id
+		}
+		id++
+	}
+
+	var dfs func(u int, x int) int
+	dfs = func(u int, x int) int {
+		var cnt int
+		x = min(x, val[u])
+		for _, v := range adj[u] {
+			cnt += dfs(v, x)
+		}
+
+		if u < n && deg[u]%2 == 1 {
+			cnt++
+		}
+		tot += (cnt / 2) * x
+		return cnt & 1
+	}
+
+	dfs(id-1, inf)
+
+	return tot
+}

--- a/src/codeforces/set2/set21/set216/set2164/e/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2164/e/solution_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Fatalf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `5 6
+2 4 15
+2 5 4
+1 3 6
+2 3 9
+1 2 10
+3 4 7
+`
+	expect := 58
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `4 3
+1 2 3
+1 3 2
+1 4 1
+`
+	expect := 8
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `2 3
+1 2 1
+2 1 3
+1 1 4
+`
+	expect := 8
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `6 6
+2 3 10
+1 3 10
+5 6 10
+6 6 1
+4 5 10
+3 4 10
+`
+	expect := 71
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `5 5
+1 2 4
+5 1 5
+4 3 6
+2 4 10
+1 4 7
+`
+	expect := 43
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set216/set2165/b/problem.md
+++ b/src/codeforces/set2/set21/set216/set2165/b/problem.md
@@ -1,0 +1,117 @@
+# Problem
+
+You are given a multiset $a$, which consists of $n$ integers $a_1, a_2, \ldots, a_n$. You would like to generate a new multiset $s$ through the following procedure:
+
+1. Partition $a$ into any number of non-empty multisets $x_1, x_2, \ldots, x_k$, such that each element of $a$ belongs to exactly one of these multisets.
+2. Initially, $s$ is empty. From each $x_i$, choose one of its modes[^mode] and insert it into $s$.
+
+Please count the number of different multisets $s$ that can be generated through the procedure, modulo $998244353$.
+
+Please note that the number of different multisets is counted, which means that the order of elements does not matter. However, the count of each element does matter, i.e. $\{1, 1, 2\}$, $\{1, 2\}$, $\{1, 1, 2, 2\}$ are all considered different.
+
+[^mode]: The mode of a multiset is defined as the element which appears the most; if several elements are tied as the maximum, then all of them are considered modes.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases $t$ ($1 \le t \le 5000$). The description of the test cases follows.
+
+The first line of each test case contains a single integer $n$ ($1 \le n \le 5000$) — the size of multiset $a$.
+
+The second line of each test case contains $n$ integers $a_1, a_2, \ldots, a_n$ ($1 \le a_i \le n$).
+
+It is guaranteed that the sum of $n$ over all test cases does not exceed $5000$.
+
+## Output
+
+For each test case, print one line containing a single integer — the number of different multisets you can obtain, modulo $998244353$.
+
+## Example
+
+### Input
+
+```
+5
+3
+1 2 3
+3
+1 1 1
+3
+1 2 2
+10
+1 1 1 1 2 2 2 3 3 4
+10
+1 1 1 2 2 2 3 3 3 4
+```
+
+### Output
+
+```
+7
+3
+4
+111
+126
+```
+
+## Note
+
+In the first test case, any non-empty subset of $\{1, 2, 3\}$ can be achieved, for a total of $7$ multisets.
+
+In the third test case, we can generate $4$ different multisets:
+
+- Partition the elements into multiset $\{1, 2, 2\}$, resulting in multiset $\{2\}$.
+- Partition the elements into multisets $\{1, 2\}$, $\{2\}$, resulting in multiset $\{2, 2\}$.
+- Partition the elements into multisets $\{1\}$, $\{2, 2\}$, resulting in multiset $\{1, 2\}$.
+- Partition the elements into multisets $\{1\}$, $\{2\}$, $\{2\}$, resulting in multiset $\{1, 2, 2\}$.
+
+It can be proven that no other multisets are possible.
+
+
+### ideas
+1. have no ideas at all!
+2. Let `cnt[v]` be the frequency of value `v` in the original multiset, and let `mx = max(cnt[v])`.
+3. Try to characterize a possible final multiset `s` only by its support `T`:
+   the set of values that appear at least once in `s`.
+4. Suppose the partition parts are `x_1, ..., x_k`. If the chosen mode in group `x_i`
+   appears `r_i` times inside that group, then every value appears at most `r_i` times
+   in that group.
+5. Therefore for any fixed original value `v`, all `cnt[v]` copies of `v` must be placed
+   across the groups, and group `i` can hold at most `r_i` copies of `v`. So:
+
+   `cnt[v] <= r_1 + r_2 + ... + r_k`
+
+6. Now ask: how large can `r_1 + ... + r_k` be?
+   Every group chooses a mode from the support `T`. If a group chooses value `x`,
+   its contribution to the sum is the number of copies of `x` used in that group.
+   Summed over all groups choosing `x`, this cannot exceed `cnt[x]`.
+   Hence:
+
+   `r_1 + ... + r_k <= sum(cnt[x] for x in T)`
+
+7. Combine the two facts for the most frequent value:
+
+   `mx <= r_1 + ... + r_k <= sum(cnt[x] for x in T)`
+
+   So a necessary condition is:
+
+   `sum(cnt[x] for x in T) >= mx`
+
+8. This condition is also sufficient. Think in a "capacity" way:
+   if you choose any support `T` with total frequency at least `mx`, then you can split
+   the copies of each `x in T` into positive parts; these parts become the mode-frequencies
+   of groups labeled by `x`. The total capacity is enough to place every unchosen value.
+
+9. Once `T` is fixed, how many different multisets `s` have exactly this support?
+   For each `x in T`, its multiplicity in `s` can be any integer from `1` to `cnt[x]`.
+   So the number of such `s` is:
+
+   `prod(cnt[x] for x in T)`
+
+10. That suggests a knapsack / DP over the distinct values:
+    - skip value with frequency `c`
+    - take it into the support, multiplying ways by `c` and increasing support-sum by `c`
+
+11. Final counting formula:
+    sum `prod(cnt[x])` over all support sets `T` such that
+
+    `sum(cnt[x] for x in T) >= mx`

--- a/src/codeforces/set2/set21/set216/set2165/b/solution.go
+++ b/src/codeforces/set2/set21/set216/set2165/b/solution.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+const mod = 998244353
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return a * b % mod
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+func solve(a []int) int {
+	slices.Sort(a)
+	var mx int
+	n := len(a)
+	var freq []int
+	for i := 0; i < n; {
+		j := i
+		for i < n && a[i] == a[j] {
+			i++
+		}
+		mx = max(mx, i-j)
+		freq = append(freq, i-j)
+	}
+	// dp[s] = sum of prod(cnt[x]) over supports T with sum(cnt)=s (0/1 knapsack on distinct values).
+	dp := make([]int, n+1)
+	dp[0] = 1
+	for _, c := range freq {
+		for s := n - c; s >= 0; s-- {
+			if dp[s] != 0 {
+				dp[s+c] = add(dp[s+c], mul(dp[s], c))
+			}
+		}
+	}
+
+	var res int
+	for i := mx; i <= n; i++ {
+		res = add(res, dp[i])
+	}
+	return res
+}

--- a/src/codeforces/set2/set21/set216/set2165/b/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2165/b/solution_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3
+1 2 3
+`
+	expect := 7
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3
+1 1 1
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `3
+1 2 2
+`
+	expect := 4
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `10
+1 1 1 1 2 2 2 3 3 4
+`
+	expect := 111
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `10
+1 1 1 2 2 2 3 3 3 4
+`
+	expect := 126
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set216/set2166/b/problem.md
+++ b/src/codeforces/set2/set21/set216/set2166/b/problem.md
@@ -1,0 +1,68 @@
+# Problem
+
+Flower gives Gellyfish two permutations[^perm] of $[0, 1, \ldots, n-1]$: $p_0, p_1, \ldots, p_{n-1}$ and $q_0, q_1, \ldots, q_{n-1}$.
+
+Now Gellyfish wants to calculate an array $r_0, r_1, \ldots, r_{n-1}$ through the following method:
+
+For all $i$ ($0 \le i \le n-1$),
+
+$$
+r_i = \max_{j=0}^{i} \left(2^{p_j} + 2^{q_{i-j}}\right).
+$$
+
+But since Gellyfish is very lazy, you have to help her figure out the elements of $r$.
+
+Since the elements of $r$ are very large, you are only required to output the elements of $r$ modulo $998244353$.
+
+[^perm]: An array $b$ is a permutation of an array $a$ if $b$ consists of the elements of $a$ in arbitrary order. For example, $[4, 2, 3, 4]$ is a permutation of $[3, 2, 4, 4]$ while $[1, 2, 2]$ is not a permutation of $[1, 2, 3]$.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases $t$ ($1 \le t \le 10^4$). The description of the test cases follows.
+
+The first line of each test case contains a single integer $n$ ($1 \le n \le 10^5$).
+
+The second line of each test case contains $n$ integers $p_0, p_1, \ldots, p_{n-1}$ ($0 \le p_i < n$).
+
+The third line of each test case contains $n$ integers $q_0, q_1, \ldots, q_{n-1}$ ($0 \le q_i < n$).
+
+It is guaranteed that both $p$ and $q$ are permutations of $[0, 1, \ldots, n-1]$.
+
+It is guaranteed that the sum of $n$ over all test cases does not exceed $10^5$.
+
+## Output
+
+For each test case, output $n$ integers $r_0, r_1, \ldots, r_{n-1}$ in a single line, modulo $998244353$.
+
+## Example
+
+### Input
+
+```
+3
+3
+0 2 1
+1 2 0
+5
+0 1 2 3 4
+4 3 2 1 0
+10
+5 8 9 3 4 0 2 7 1 6
+9 5 1 4 0 3 2 8 7 6
+```
+
+### Output
+
+```
+3 6 8
+17 18 20 24 32
+544 768 1024 544 528 528 516 640 516 768
+```
+
+## Note
+
+In the first test case:
+
+- $r_0 = 2^{p_0} + 2^{q_0} = 1 + 2 = 3$
+- $r_1 = \max(2^{p_0} + 2^{q_1},\, 2^{p_1} + 2^{q_0}) = \max(1 + 4,\, 4 + 2) = 6$
+- $r_2 = \max(2^{p_0} + 2^{q_2},\, 2^{p_1} + 2^{q_1},\, 2^{p_2} + 2^{q_0}) = \max(1 + 1,\, 4 + 4,\, 2 + 2) = 8$

--- a/src/codeforces/set2/set21/set216/set2166/b/solution.go
+++ b/src/codeforces/set2/set21/set216/set2166/b/solution.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+const N = 100010
+
+const mod = 998244353
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return a * b % mod
+}
+
+var P [N]int
+
+func init() {
+	P[0] = 1
+	for i := 1; i < N; i++ {
+		P[i] = mul(P[i-1], 2)
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	p := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &p[i])
+	}
+	q := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &q[i])
+	}
+	return solve(p, q)
+}
+
+type pair struct {
+	first  int
+	second int
+}
+
+func (p pair) swap() pair {
+	return pair{p.second, p.first}
+}
+
+func solve(p []int, q []int) []int {
+	pos := []int{0, 0}
+	n := len(p)
+	res := make([]int, n)
+
+	res[0] = add(P[p[0]], P[q[0]])
+
+	cmpAndGet := func(i int, j int) pair {
+		return pair{p[j], q[i-j]}
+	}
+
+	for i := 1; i < n; i++ {
+		if p[i] > p[pos[0]] {
+			pos[0] = i
+		}
+		if q[i] > q[pos[1]] {
+			pos[1] = i
+		}
+
+		f := cmpAndGet(i, pos[0])
+		s := cmpAndGet(i, i-pos[1]).swap()
+		if f.first > s.first || f.first == s.first && f.second > s.second {
+			res[i] = add(P[f.first], P[f.second])
+		} else {
+			res[i] = add(P[s.first], P[s.second])
+		}
+
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set21/set216/set2166/b/solution_test.go
+++ b/src/codeforces/set2/set21/set216/set2166/b/solution_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	expect := make([]int, len(res))
+	for i := range len(res) {
+		fmt.Fscan(reader, &expect[i])
+	}
+
+	if !slices.Equal(res, expect) {
+		t.Fatalf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3
+0 2 1
+1 2 0
+3 6 8
+`
+	runSample(t, s)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5
+0 1 2 3 4
+4 3 2 1 0
+17 18 20 24 32
+`
+	runSample(t, s)
+}
+
+func TestSample3(t *testing.T) {
+	s := `10
+5 8 9 3 4 0 2 7 1 6
+9 5 1 4 0 3 2 8 7 6
+544 768 1024 544 528 528 516 640 516 768
+`
+	runSample(t, s)
+}


### PR DESCRIPTION
## Summary
- add new Codeforces packages for set2163/c, set2164/d, set2164/e, set2165/b, and set2166/b with `solution.go`, `solution_test.go`, and `problem.md`
- update `set1862/f/solution.go` and refine DP/IO implementations plus extra sample coverage in recently added tests
- normalize and format multiple problem statements for readability and future notes

## Test plan
- [x] Run `go test ./src/codeforces/set2/set21/set216/set2164/d/ -v`
- [x] Run `go test ./src/codeforces/set2/set21/set216/set2165/b/ -v`
- [ ] Run `go test` for each newly added package before release

Made with [Cursor](https://cursor.com)