### PR TITLE
Add CF 2194D and 2207/2208 updates

### DIFF
--- a/src/codeforces/set1/set15/set156/set1560/f2/solution.go
+++ b/src/codeforces/set1/set15/set156/set1560/f2/solution.go
@@ -2,84 +2,101 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
+	"math/bits"
 	"os"
+	"slices"
 )
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
-	tc := readNum(reader)
-	var buf bytes.Buffer
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
 
 	for tc > 0 {
 		tc--
-		n, k := readTwoNums(reader)
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
 		res := solve(n, k)
-		buf.WriteString(fmt.Sprintf("%d\n", res))
+		fmt.Fprintln(writer, res)
 	}
 
-	fmt.Print(buf.String())
 }
 
-func readString(r *bufio.Reader) string {
-	s, _ := r.ReadString('\n')
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' || s[i] == '\r' {
-			return s[:i]
-		}
-	}
-	return s
-}
-
-func readInt(bytes []byte, from int, val *int) int {
-	i := from
-	sign := 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	tmp := 0
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readNum(reader *bufio.Reader) (a int) {
-	bs, _ := reader.ReadBytes('\n')
-	readInt(bs, 0, &a)
-	return
-}
-
-func readTwoNums(reader *bufio.Reader) (a int, b int) {
-	res := readNNums(reader, 2)
-	a, b = res[0], res[1]
-	return
-}
-
-func readThreeNums(reader *bufio.Reader) (a int, b int, c int) {
-	res := readNNums(reader, 3)
-	a, b, c = res[0], res[1], res[2]
-	return
-}
-
-func readNNums(reader *bufio.Reader, n int) []int {
-	res := make([]int, n)
-	x := 0
-	bs, _ := reader.ReadBytes('\n')
-	for i := 0; i < n; i++ {
-		for x < len(bs) && (bs[x] < '0' || bs[x] > '9') && bs[x] != '-' {
-			x++
-		}
-		x = readInt(bs, x, &res[i])
-	}
-	return res
-}
+var dp [1 << 10][2]int
+var ndp [1 << 10][2]int
 
 const inf = 11111111111111
+
+func solve1(n int, k int) int {
+	var digits []int
+	for i := n; i > 0; i /= 10 {
+		digits = append(digits, i%10)
+	}
+
+	slices.Reverse(digits)
+
+	for mask := range 1 << 10 {
+		for eq := range 2 {
+			dp[mask][eq] = inf
+			ndp[mask][eq] = inf
+		}
+	}
+
+	var states []int
+	for mask := range 1 << 10 {
+		if bits.OnesCount(uint(mask)) <= k {
+			states = append(states, mask)
+		}
+	}
+
+	dp[0][1] = 0
+	for _, d := range digits {
+		for _, mask := range states {
+			cur := dp[mask]
+			for eq, v := range cur {
+				if v < inf {
+					for x := range 10 {
+						if eq == 1 && x < d {
+							continue
+						}
+						newMask := mask | (1 << x)
+						nv := v*10 + x
+						neq := eq
+						if eq == 1 && x > d {
+							neq = 0
+						}
+						if bits.OnesCount(uint(newMask)) > k {
+							continue
+						}
+						ndp[newMask][neq] = min(ndp[newMask][neq], nv)
+					}
+				}
+			}
+		}
+
+		for _, mask := range states {
+			for eq := range 2 {
+				dp[mask][eq] = ndp[mask][eq]
+				ndp[mask][eq] = inf
+			}
+		}
+	}
+	best := inf
+	for _, mask := range states {
+		for _, v := range dp[mask] {
+			if v < inf {
+				best = min(best, v)
+			}
+		}
+	}
+	if best < inf {
+		return best
+	}
+	return -1
+}
 
 func solve(n int, k int) int {
 	if countDigits(n) <= k {

--- a/src/codeforces/set2/set21/set219/set2194/d/problem.md
+++ b/src/codeforces/set2/set21/set219/set2194/d/problem.md
@@ -1,0 +1,77 @@
+# Problem
+
+Given a table of size `n × m`, where each cell contains either `0` or `1`, divide it into two parts by a cut that goes from the top-left corner to the bottom-right corner.
+
+The cut can move only **right** or **down**.
+
+Let:
+
+- `a` = number of ones in one part,
+- `b` = number of ones in the other part.
+
+Your goal is to maximize `a * b`.
+
+## Input
+
+The first line contains integer `t` (`1 ≤ t ≤ 10^4`) — number of test cases.
+
+Each test case:
+
+- First line: two integers `n` and `m` (`1 ≤ n, m ≤ 3 * 10^5`, `2 ≤ n * m ≤ 3 * 10^5`) — table dimensions.
+- Next `n` lines: each contains `m` integers `ai,j` (`0 ≤ ai,j ≤ 1`) — table values.
+
+It is guaranteed that the sum of `n * m` over all test cases does not exceed `3 * 10^5`.
+
+## Output
+
+For each test case:
+
+1. Print one integer — the maximum product value.
+2. Print one string describing the cut path:
+   - consisting of exactly `n - 1` characters `'D'` and `m - 1` characters `'R'`,
+   - where `'D'` means move cut down, and `'R'` means move cut right.
+
+If there are multiple optimal cuts, print any.
+
+## Example
+
+**Input**
+
+```text
+3
+5 5
+1 0 1 1 0
+0 1 0 1 1
+1 0 1 0 0
+0 1 0 1 0
+0 0 0 0 1
+5 4
+0 0 1 0
+0 1 1 1
+1 0 0 1
+0 1 0 1
+0 0 1 0
+3 2
+1 0
+0 1
+1 1
+```
+
+**Output**
+
+```text
+30
+RDRDRDRDDR
+20
+DRRDRDDDR
+4
+DRDRD
+```
+
+## Note
+
+The statement figures show valid optimal cuts for the first and second test cases.
+
+
+### ideas
+1. 这个咋这么难的～

--- a/src/codeforces/set2/set21/set219/set2194/d/solution.go
+++ b/src/codeforces/set2/set21/set219/set2194/d/solution.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		_, score, res := drive(reader)
+		fmt.Fprintln(writer, score)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) (a [][]int, score int, res string) {
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	a = make([][]int, n)
+	for i := range n {
+		a[i] = make([]int, m)
+		for j := range m {
+			fmt.Fscan(reader, &a[i][j])
+		}
+	}
+	score, res = solve(a)
+	return
+}
+
+func solve(a [][]int) (score int, res string) {
+	n := len(a)
+	m := len(a[0])
+	var sum int
+	for _, row := range a {
+		for _, v := range row {
+			sum += v
+		}
+	}
+	// x + y = sum
+	// n * m 还挺大的
+	// x = sum / 2， 这个结果是不是一定可以得到？
+	// 好像可以得到的。假设一开始通过某种分配，得到了x0 > x
+	// 那么这个时候，可以从最底下开始调整，如果这一行右边有 x0 - x 个1，那么就一直往右边移动
+	// 如果不够，就继续往上, 所以肯定可以
+	x := sum / 2
+	var buf []byte
+
+	var cur int
+	for i, row := range a {
+		var tmp int
+		for _, v := range row {
+			tmp += v
+		}
+		if cur+tmp < x {
+			cur += tmp
+			buf = append(buf, 'D')
+			continue
+		}
+		if cur+tmp == x {
+			buf = append(buf, 'D')
+			for range m {
+				buf = append(buf, 'R')
+			}
+		} else {
+			// cur + tmp > x
+			down := false
+			for _, v := range row {
+				buf = append(buf, 'R')
+				tmp -= v
+				if cur+tmp == x && !down {
+					down = true
+					buf = append(buf, 'D')
+				}
+			}
+		}
+
+		for i1 := i + 1; i1 < n; i1++ {
+			buf = append(buf, 'D')
+		}
+
+		break
+	}
+
+	return x * (sum - x), string(buf)
+}

--- a/src/codeforces/set2/set21/set219/set2194/d/solution_test.go
+++ b/src/codeforces/set2/set21/set219/set2194/d/solution_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	a, score, res := drive(reader)
+	if score != expect {
+		t.Fatalf("expect %d, but got %d", expect, score)
+	}
+	n := len(a)
+	m := len(a[0])
+	if n+m != len(res) {
+		t.Fatalf("expect %d, but got %d", n+m, len(res))
+	}
+	row := make([]int, n)
+	for r, c, i := 0, 0, 0; i < len(res); i++ {
+		if res[i] == 'D' {
+			row[r] = c
+			r++
+		} else {
+			c++
+			if c > m {
+				t.Fatalf("Sample result %s, not valid, it exceeds the column limit %d", res, m)
+			}
+		}
+	}
+	sum := []int{0, 0}
+	for i := range n {
+		for j := range m {
+			if j < row[i] {
+				sum[0] += a[i][j]
+			} else {
+				sum[1] += a[i][j]
+			}
+		}
+	}
+	if sum[0]*sum[1] != score {
+		t.Fatalf("Sample result %s, not correct, score %d, but got %d", res, score, sum[0]*sum[1])
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `5 5
+1 0 1 1 0
+0 1 0 1 1
+1 0 1 0 0
+0 1 0 1 0
+0 0 0 0 1
+`
+	expect := 30
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5 4
+0 0 1 0
+0 1 1 1
+1 0 0 1
+0 1 0 1
+0 0 1 0
+`
+	expect := 20
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `3 2
+1 0
+0 1
+1 1
+`
+	expect := 4
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set22/set220/set2207/c/problem.md
+++ b/src/codeforces/set2/set22/set220/set2207/c/problem.md
@@ -1,0 +1,111 @@
+# Problem
+
+Let `n` and `h` be positive integers. Swampy the Alligator needs water for his bathtub, and you are tasked with getting it to him.
+
+Above his house, there is an `h × n` grid of dirt and water tiles, with columns numbered `1..n`.
+
+In column `i`, the bottom `ai` tiles are dirt, and the remaining top tiles are water.
+
+You may place a drain on any non-dirt tile. Placing a drain removes all water tiles that can reach that drain by moving only **down**, **left**, or **right**, without crossing dirt tiles.
+
+What is the maximum amount of water you can get to Swampy by placing at most **two** drains?
+
+If a water tile can be removed by either drain, it is counted only once.
+
+## Input
+
+The first line contains integer `t` (`1 ≤ t ≤ 10^3`) — the number of test cases.
+
+For each test case:
+
+- First line: two integers `n` and `h` (`1 ≤ n ≤ 2000`, `1 ≤ h ≤ 10^9`) — number of columns and grid height.
+- Second line: `n` integers `a1, a2, ..., an` (`1 ≤ ai ≤ h`) — dirt height in each column.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2000`.
+
+## Output
+
+For each test case, print one integer — the maximum number of water tiles that can be drained using at most two drains.
+
+## Example
+
+**Input**
+
+```text
+6
+7 4
+1 3 1 2 3 1 1
+8 10
+7 5 1 3 2 5 6 8
+1 1
+1
+10 20
+5 2 1 2 1 3 6 7 1 1
+5 1000000000
+1 420420420 1 420420420 1
+1 1000000000
+1
+```
+
+**Output**
+
+```text
+14
+43
+0
+170
+3738738738
+999999999
+```
+
+## Note
+
+In the first test case, it is possible to drain `14` tiles of water by placing two drains as shown in the statement figure.
+
+In the second test case, it is possible to drain all `43` water tiles.
+
+In the third test case, the grid has only one dirt tile and no drain can be placed, so the answer is `0`.
+
+
+### ideas
+1. 考虑只有1个drain时的情况
+2. 假设在某个i处，放置了一个drain，那么它可以抽取的水量
+3. = 左边 + 右边。左边是一个递减的stack；右边是一个递增的stack
+4. (h - h1) * w1 + (h - h2) * w2 + ... (h - hi) * wi
+5. h * w1 + h * w2 + ... - h1 * w1 - h2 * w2... 
+6. h * i - h1 * w1 - h2 * w2 ...
+7. 单个的可以这样算; 
+8. 考虑两个要怎么算呢？
+9. 首先，可以判断的是，这两个里面，肯定有一个是最优，流出最大的那个
+10. 假设最优答案不是最优的，那么通过交换成最优的一个，答案会更好
+11. 这时候，它不可能包含第二个（因为包含第二个的时候，第二个就是最优的）
+12. 然后，把被第一个抽干的部分，全部填满，然后再跑一次就可以了
+13. 不大对～
+14. 虽然做对了，但是不像1600分呐
+
+## key insights
+
+1. For one drain at column `i`, drained water equals:
+   - sum of `(h - a[x])` over all columns `x` that can connect to `i` through moves left/right/down.
+   - In 1D column terms, this is determined by nearest higher barriers on both sides.
+
+2. The code precomputes directional contribution stacks via `play(a)`:
+   - It scans left to right with a monotonic decreasing stack by height `a[idx]`.
+   - For each position `i`, it computes cumulative drainable water from the left side.
+   - `dp[i]` stores a snapshot of this stack, where stack top contains the best cumulative value up to `i`.
+
+3. To get right-side symmetric information, it reuses the same routine on reversed array:
+   - `fp = play(reverse(a))`, then reverse back.
+   - So `top(dp[x]).second` and `top(fp[x]).second` act like one-drain totals seen from left/right preprocessing.
+
+4. Then it enumerates pairs `(l, r)` of drain columns (`O(n^2)`):
+   - start from sum of independent left/right totals,
+   - identify `hi` = index of maximum `a` in `[l..r]`,
+   - apply inclusion-exclusion style corrections to avoid double counting overlap between two drains,
+   - special-case `l == r` as single-drain answer.
+
+5. Why this passes limits:
+   - `sum n <= 2000`, so `O(n^2)` per test case (plus linear preprocessing) is acceptable.
+   - Stack operations in preprocessing are amortized linear.
+
+6. Final answer is the maximum corrected value over all `(l, r)`.

--- a/src/codeforces/set2/set22/set220/set2207/c/solution.go
+++ b/src/codeforces/set2/set22/set220/set2207/c/solution.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, h int
+	fmt.Fscan(reader, &n, &h)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(h, a)
+}
+
+type pair struct {
+	first  int
+	second int
+}
+
+func solve(h int, a []int) int {
+	n := len(a)
+
+	// dp[i] 是从i开始的左边的阶梯（递减）
+	play := func(a []int) []int {
+		dp := make([]int, n)
+		var stack []pair
+		for i := range n {
+			for len(stack) > 0 && a[top(stack).first] <= a[i] {
+				stack = stack[:len(stack)-1]
+			}
+
+			w := (h - a[i]) * (i + 1)
+			if len(stack) > 0 {
+				p := top(stack)
+				w = p.second + (h-a[i])*(i-p.first)
+			}
+			stack = append(stack, pair{i, w})
+			dp[i] = w
+		}
+		return dp
+	}
+
+	dp := play(a)
+	slices.Reverse(a)
+	fp := play(a)
+	slices.Reverse(a)
+	slices.Reverse(fp)
+
+	var best int
+
+	for l := range n {
+		hi := l
+		for r := l; r < n; r++ {
+			if l == r {
+				tmp := dp[l] + fp[r] - (h - a[l])
+				best = max(best, tmp)
+			} else {
+				if a[hi] < a[r] {
+					hi = r
+				}
+				tmp := dp[l] + fp[r]
+
+				if hi != l {
+					tmp += fp[l] - fp[hi] - (h - a[l])
+				}
+				if hi != r {
+					tmp += dp[r] - dp[hi] - (h - a[r])
+				}
+
+				if hi != l && hi != r {
+					tmp += (h - a[hi])
+				}
+
+				best = max(best, tmp)
+			}
+		}
+	}
+
+	return best
+}
+
+func top[T any](stack []T) T {
+	return stack[len(stack)-1]
+}

--- a/src/codeforces/set2/set22/set220/set2207/c/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2207/c/solution_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `7 4
+1 3 1 2 3 1 1
+`
+	expect := 14
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `8 10
+7 5 1 3 2 5 6 8
+`
+	expect := 43
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `1 1
+1
+`
+	expect := 0
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `10 20
+5 2 1 2 1 3 6 7 1 1
+`
+	expect := 170
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `5 1000000000
+1 420420420 1 420420420 1
+`
+	expect := 3738738738
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `1 1000000000
+1
+`
+	expect := 999999999
+	runSample(t, s, expect)
+}
+

--- a/src/codeforces/set2/set22/set220/set2208/d1/problem.md
+++ b/src/codeforces/set2/set22/set220/set2208/d1/problem.md
@@ -1,0 +1,139 @@
+# Problem
+
+You once had an undirected tree with `n` nodes. To make the tree look more interesting, you assigned an **arbitrary direction** to each of the `n - 1` edges.
+
+Over time you forgot the tree structure. You found a note that records, **after** orienting the edges, for every ordered pair `(u, v)` with `1 ≤ u, v ≤ n`, whether `u` can reach `v` in the resulting directed graph.
+
+You must recover **some** tree structure and edge directions consistent with the note, or report that none exists. If multiple solutions exist, print any.
+
+For a directed graph, `x` can reach `y` if and only if there is a sequence of nodes `u1, u2, ..., uk` such that `u1 = x`, `uk = y`, and for every `i` from `2` to `k` the directed edge `u(i-1) → ui` exists. In particular, every node can reach itself.
+
+## Input
+
+The first line contains integer `t` (`1 ≤ t ≤ 10^4`) — the number of test cases.
+
+Each test case:
+
+- First line: integer `n` (`2 ≤ n ≤ 500`) — number of nodes.
+- Next `n` lines: string `si` of length `n`, consisting only of `'0'` and `'1'`.
+  The `j`-th character of `si` is `'1'` if and only if node `i` can reach node `j` after the edges are directed.
+
+It is guaranteed that the sum of `n^3` over all test cases does not exceed `500^3`.
+
+## Output
+
+For each test case:
+
+- If a solution exists, print `Yes` (case-insensitive accepted, e.g. `yEs`, `YES`).
+- Then print `n - 1` lines, each with two integers `x` and `y`, meaning there is a directed edge `x → y` in your oriented tree.
+
+If no solution exists, print `No` (case-insensitive accepted).
+
+If there are multiple valid trees/orientations, print any.
+
+## Example
+
+### Input
+
+```text
+11
+4
+1000
+1111
+1010
+0001
+4
+1111
+0111
+0010
+0111
+4
+0011
+0111
+0011
+0001
+4
+1000
+0110
+0010
+1111
+4
+1000
+0110
+1010
+1111
+5
+10000
+01011
+00111
+00010
+00001
+5
+10000
+11000
+10101
+10111
+00001
+5
+10000
+01101
+00100
+01110
+10001
+4
+1100
+0100
+0011
+0001
+4
+1110
+0100
+0010
+0101
+3
+100
+111
+101
+```
+
+### Output
+
+```text
+Yes
+2 3
+2 4
+3 1
+No
+No
+Yes
+2 3
+4 1
+4 2
+No
+No
+Yes
+2 1
+3 1
+3 5
+4 3
+No
+No
+Yes
+1 2
+1 3
+4 2
+Yes
+2 3
+3 1
+```
+
+## Note
+
+In the first test case, nodes `1` and `4` can only reach themselves, node `2` can reach every node, and node `3` can reach only nodes `1` and `3`. The printed edges satisfy these reachability constraints.
+
+In the second test case, no valid tree and orientation exist.
+
+## Ideas
+
+1. `s[i][j] = 1` 表示从 i 能够到达 j，也就是存在一条 path: i -> ... -> j
+2. 如果 i, j 中间不存在 u，使得 `s[i][u] = 1` 且 `s[u][j] = 1`，那么 i->j 成立

--- a/src/codeforces/set2/set22/set220/set2208/d1/solution.go
+++ b/src/codeforces/set2/set22/set220/set2208/d1/solution.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	tc := readNums(reader)[0]
+	for range tc {
+		_, res := drive(reader)
+		if len(res) == 0 {
+			fmt.Fprintln(writer, "No")
+		} else {
+			fmt.Fprintln(writer, "Yes")
+			for _, e := range res {
+				fmt.Fprintln(writer, e[0], e[1])
+			}
+		}
+	}
+}
+
+func readString(reader *bufio.Reader) string {
+	s, _ := reader.ReadString('\n')
+	return strings.TrimSpace(s)
+}
+
+func readNums(reader *bufio.Reader) []int {
+	s := readString(reader)
+
+	ss := strings.Split(s, " ")
+	res := make([]int, len(ss))
+	for i := range len(ss) {
+		res[i], _ = strconv.Atoi(ss[i])
+	}
+	return res
+}
+
+func drive(reader *bufio.Reader) (s []string, res [][]int) {
+	n := readNums(reader)[0]
+	s = make([]string, n)
+	for i := range n {
+		s[i] = readString(reader)
+	}
+	res = solve(s)
+	return
+}
+
+func solve(s []string) [][]int {
+	n := len(s)
+
+	var res [][]int
+
+	findMid := func(x int, y int) int {
+		for u := range n {
+			if x == u || y == u {
+				continue
+			}
+			if s[x][u] == '1' && s[u][y] == '1' {
+				return u
+			}
+		}
+		return -1
+	}
+
+	for i := range n {
+		if s[i][i] == '0' {
+			return nil
+		}
+		for j := range n {
+			if i != j && s[i][j] == '1' {
+				u := findMid(i, j)
+				if u < 0 {
+					res = append(res, []int{i + 1, j + 1})
+				}
+			}
+		}
+	}
+
+	if len(res) != n-1 || !verify(s, res) {
+		return nil
+	}
+
+	return res
+}
+
+func verify(s []string, edges [][]int) bool {
+	n := len(s)
+
+	fa := make([]int, n)
+	for i := range n {
+		fa[i] = i
+	}
+	find := func(x int) int {
+		y := x
+		for fa[y] != y {
+			y = fa[y]
+		}
+		for fa[x] != y {
+			fa[x], x = y, fa[x]
+		}
+		return y
+	}
+
+	sz := n
+	union := func(x, y int) {
+		x = find(x)
+		y = find(y)
+		if x == y {
+			return
+		}
+		fa[x] = y
+		sz--
+	}
+
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		adj[u] = append(adj[u], v)
+		union(u, v)
+	}
+
+	que := make([]int, n)
+	check := func(x int) string {
+		buf := make([]byte, n)
+		for i := range n {
+			buf[i] = '0'
+		}
+		buf[x] = '1'
+		var head, tail int
+		que[head] = x
+		head++
+		for tail < head {
+			u := que[tail]
+			tail++
+			for _, v := range adj[u] {
+				if buf[v] == '0' {
+					buf[v] = '1'
+					que[head] = v
+					head++
+				}
+			}
+		}
+		return string(buf)
+	}
+
+	for i := range n {
+		tmp := check(i)
+		if s[i] != tmp {
+			return false
+		}
+	}
+	return sz == 1
+}

--- a/src/codeforces/set2/set22/set220/set2208/d1/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2208/d1/solution_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect bool) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	w, res := drive(reader)
+	if len(res) > 0 != expect {
+		t.Fatalf("Sample expect %t, but got %v", expect, res)
+	}
+	if !expect {
+		return
+	}
+	if !verify(w, res) {
+		t.Fatalf("Sample result %v, not correct", res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `4
+1000
+1111
+1010
+0001`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `4
+1111
+0111
+0010
+0111`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `4
+0011
+0111
+0011
+0001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `4
+1000
+0110
+0010
+1111`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `4
+1000
+0110
+1010
+1111`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `5
+10000
+01011
+00111
+00010
+00001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample7(t *testing.T) {
+	s := `5
+10000
+11000
+10101
+10111
+00001`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample8(t *testing.T) {
+	s := `5
+10000
+01101
+00100
+01110
+10001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample9(t *testing.T) {
+	s := `4
+1100
+0100
+0011
+0001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample10(t *testing.T) {
+	s := `4
+1110
+0100
+0010
+0101`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample11(t *testing.T) {
+	s := `3
+100
+111
+101`
+	expect := true
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set22/set220/set2208/d2/problem.md
+++ b/src/codeforces/set2/set22/set220/set2208/d2/problem.md
@@ -1,0 +1,169 @@
+# Problem (Hard Version)
+
+This is the hard version of the problem. The difference between the versions is that in this version, the constraint on `n` is higher. You can hack only if you solved all versions of this problem.
+
+You once had an undirected tree with `n` nodes. To make the tree look more interesting, you assigned an **arbitrary direction** to each of the `n - 1` edges.
+
+Over time you forgot the tree structure. You found a note that records, **after** orienting the edges, for every ordered pair `(u, v)` with `1 ≤ u, v ≤ n`, whether `u` can reach `v` in the resulting directed graph.
+
+You must recover **some** tree structure and edge directions consistent with the note, or report that none exists. If multiple solutions exist, print any.
+
+For a directed graph, `x` can reach `y` if and only if there is a sequence of nodes `u1, u2, ..., uk` such that `u1 = x`, `uk = y`, and for every `i` from `2` to `k` the directed edge `u(i-1) → ui` exists. In particular, every node can reach itself.
+
+## Input
+
+The first line contains integer `t` (`1 ≤ t ≤ 10^4`) — the number of test cases.
+
+Each test case:
+
+- First line: integer `n` (`2 ≤ n ≤ 8000`) — number of nodes.
+- Next `n` lines: string `si` of length `n`, consisting only of `'0'` and `'1'`.
+  The `j`-th character of `si` is `'1'` if and only if node `i` can reach node `j` after the edges are directed.
+
+It is guaranteed that the sum of `n^2` over all test cases does not exceed `8000^2`.
+
+## Output
+
+For each test case:
+
+- If a solution exists, print `Yes` (case-insensitive accepted, e.g. `yEs`, `YES`).
+- Then print `n - 1` lines, each with two integers `x` and `y`, meaning there is a directed edge `x → y` in your oriented tree.
+
+If no solution exists, print `No` (case-insensitive accepted).
+
+If there are multiple valid trees/orientations, print any.
+
+## Example
+
+### Input
+
+```text
+11
+4
+1000
+1111
+1010
+0001
+4
+1111
+0111
+0010
+0111
+4
+0011
+0111
+0011
+0001
+4
+1000
+0110
+0010
+1111
+4
+1000
+0110
+1010
+1111
+5
+10000
+01011
+00111
+00010
+00001
+5
+10000
+11000
+10101
+10111
+00001
+5
+10000
+01101
+00100
+01110
+10001
+4
+1100
+0100
+0011
+0001
+4
+1110
+0100
+0010
+0101
+3
+100
+111
+101
+```
+
+### Output
+
+```text
+Yes
+2 3
+2 4
+3 1
+No
+No
+Yes
+2 3
+4 1
+4 2
+No
+No
+Yes
+2 1
+3 1
+3 5
+4 3
+No
+No
+Yes
+1 2
+1 3
+4 2
+Yes
+2 3
+3 1
+```
+
+## Note
+
+In the first test case, nodes `1` and `4` can only reach themselves, node `2` can reach every node, and node `3` can reach only nodes `1` and `3`. The printed edges satisfy these reachability constraints.
+
+In the second test case, no valid tree and orientation exist.
+
+## Ideas
+
+1. `s[i][j] = 1` 表示从 i 能够到达 j，也就是存在一条 path: i -> ... -> j
+2. 如果 i, j 中间不存在 u，使得 `s[i][u] = 1` 且 `s[u][j] = 1`，那么 i->j 成立
+3. 关键约束：`n` 最大为 8000，sum of `n^2` ≤ `8000^2`，需要 O(n^2) 算法
+
+## Key Insights
+
+### 1. Validity check: diagonal must be all '1'
+`s[i][i]` must be `'1'` for every node (every node reaches itself). Fail immediately otherwise.
+
+### 2. Reachability defines a DAG of "reachability sets"
+Define the **out-degree** of node `i` as the number of nodes `j ≠ i` with `s[i][j] = '1'` (i.e., how many nodes `i` can reach). The reachability relation on a directed tree is a partial order — it must be acyclic (no two distinct nodes can mutually reach each other unless they are the same node).
+
+### 3. Topological sort as the processing order
+Compute in-degree in the reachability graph (how many nodes can reach `i`, excluding `i` itself). Nodes with in-degree 0 are "roots" — nothing reaches them except themselves. Run a standard BFS-based topological sort. If not all `n` nodes are processed, a cycle exists in the reachability relation → output `No`.
+
+The topological order `que[]` gives a safe DFS traversal order: when we visit `u`, all nodes that can reach `u` have already been processed.
+
+### 4. Spanning tree construction via Union-Find
+Traverse nodes in topological order. For each node `u`, iterate over all `v` with `s[u][v] = '1'`. If `u` and `v` are in **different components** (Union-Find), add the directed edge `u → v` and merge their components. This greedily builds a spanning tree using only edges that exist in the reachability graph.
+
+The key invariant: we only add edge `u → v` when `u` can reach `v` (`s[u][v] = '1'`), and we avoid cycles by checking Union-Find membership.
+
+### 5. Final verification
+After constructing the candidate tree (exactly `n-1` edges, all nodes connected), run BFS from every node on the candidate directed tree and compare the reachability string against the input `s[i]`. This catches cases where the greedy construction produced a structurally valid tree but with wrong reachability (e.g., missing transitive edges). The verify step is O(n²) total.
+
+### 6. Complexity
+- Topological sort: O(n²)
+- Spanning tree DFS + Union-Find: O(n²)  
+- Verification (n BFS runs): O(n²)  
+- Total: **O(n²)** per test case, fitting within the `sum of n² ≤ 8000²` constraint.

--- a/src/codeforces/set2/set22/set220/set2208/d2/solution.go
+++ b/src/codeforces/set2/set22/set220/set2208/d2/solution.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	tc := readNums(reader)[0]
+	for range tc {
+		_, res := drive(reader)
+		if len(res) == 0 {
+			fmt.Fprintln(writer, "No")
+		} else {
+			fmt.Fprintln(writer, "Yes")
+			for _, e := range res {
+				fmt.Fprintln(writer, e[0], e[1])
+			}
+		}
+	}
+}
+
+func readString(reader *bufio.Reader) string {
+	s, _ := reader.ReadString('\n')
+	return strings.TrimSpace(s)
+}
+
+func readNums(reader *bufio.Reader) []int {
+	s := readString(reader)
+
+	ss := strings.Split(s, " ")
+	res := make([]int, len(ss))
+	for i := range len(ss) {
+		res[i], _ = strconv.Atoi(ss[i])
+	}
+	return res
+}
+
+func drive(reader *bufio.Reader) (s []string, res [][]int) {
+	n := readNums(reader)[0]
+	s = make([]string, n)
+	for i := range n {
+		s[i] = readString(reader)
+	}
+	res = solve(s)
+	return
+}
+
+func solve(s []string) [][]int {
+	n := len(s)
+	deg := make([]int, n)
+	for i := range n {
+		if s[i][i] == '0' {
+			return nil
+		}
+		for j := range n {
+			if i != j && s[i][j] == '1' {
+				deg[j]++
+			}
+		}
+	}
+
+	que := make([]int, n)
+	var head, tail int
+	for i := range n {
+		if deg[i] == 0 {
+			que[head] = i
+			head++
+		}
+	}
+
+	for tail < head {
+		u := que[tail]
+		tail++
+		for v := range n {
+			if u != v && s[u][v] == '1' {
+				deg[v]--
+				if deg[v] == 0 {
+					que[head] = v
+					head++
+				}
+			}
+		}
+	}
+
+	if head != n {
+		return nil
+	}
+
+	fa := make([]int, n)
+	for i := range n {
+		fa[i] = i
+	}
+	find := func(x int) int {
+		y := x
+		for fa[y] != y {
+			y = fa[y]
+		}
+		for fa[x] != y {
+			fa[x], x = y, fa[x]
+		}
+		return y
+	}
+
+	var res [][]int
+	marked := make([]bool, n)
+	var dfs func(u int)
+	dfs = func(u int) {
+		marked[u] = true
+		for _, v := range que {
+			if u != v && s[u][v] == '1' {
+				if find(v) != find(u) {
+					res = append(res, []int{u + 1, v + 1})
+					fa[find(v)] = u
+				}
+				if !marked[v] {
+					dfs(v)
+				}
+			}
+		}
+	}
+
+	for _, u := range que {
+		if !marked[u] {
+			dfs(u)
+		}
+	}
+
+	if len(res) != n-1 || !verify(s, res) {
+		return nil
+	}
+	return res
+}
+
+func verify(s []string, edges [][]int) bool {
+	n := len(s)
+
+	fa := make([]int, n)
+	for i := range n {
+		fa[i] = i
+	}
+	find := func(x int) int {
+		y := x
+		for fa[y] != y {
+			y = fa[y]
+		}
+		for fa[x] != y {
+			fa[x], x = y, fa[x]
+		}
+		return y
+	}
+
+	sz := n
+	union := func(x, y int) {
+		x = find(x)
+		y = find(y)
+		if x == y {
+			return
+		}
+		fa[x] = y
+		sz--
+	}
+
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		adj[u] = append(adj[u], v)
+		union(u, v)
+	}
+
+	que := make([]int, n)
+	check := func(x int) string {
+		buf := make([]byte, n)
+		for i := range n {
+			buf[i] = '0'
+		}
+		buf[x] = '1'
+		var head, tail int
+		que[head] = x
+		head++
+		for tail < head {
+			u := que[tail]
+			tail++
+			for _, v := range adj[u] {
+				if buf[v] == '0' {
+					buf[v] = '1'
+					que[head] = v
+					head++
+				}
+			}
+		}
+		return string(buf)
+	}
+
+	for i := range n {
+		tmp := check(i)
+		if s[i] != tmp {
+			return false
+		}
+	}
+	return sz == 1
+}

--- a/src/codeforces/set2/set22/set220/set2208/d2/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2208/d2/solution_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect bool) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	w, res := drive(reader)
+	if len(res) > 0 != expect {
+		t.Fatalf("Sample expect %t, but got %v", expect, res)
+	}
+	if !expect {
+		return
+	}
+	if !verify(w, res) {
+		t.Fatalf("Sample result %v, not correct", res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `4
+1000
+1111
+1010
+0001`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `4
+1111
+0111
+0010
+0111`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `4
+0011
+0111
+0011
+0001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `4
+1000
+0110
+0010
+1111`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `4
+1000
+0110
+1010
+1111`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `5
+10000
+01011
+00111
+00010
+00001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample7(t *testing.T) {
+	s := `5
+10000
+11000
+10101
+10111
+00001`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample8(t *testing.T) {
+	s := `5
+10000
+01101
+00100
+01110
+10001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample9(t *testing.T) {
+	s := `4
+1100
+0100
+0011
+0001`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample10(t *testing.T) {
+	s := `4
+1110
+0100
+0010
+0101`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample11(t *testing.T) {
+	s := `3
+100
+111
+101`
+	expect := true
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- Add solution implementations and tests for Codeforces 2194D, 2207C, and 2208 (D1/D2).
- Format and refine corresponding problem statements for consistent structure.
- Expand sample coverage in tests for the newly added tasks.

## Test plan
- [ ] Run package tests for affected problem folders

Made with [Cursor](https://cursor.com)