### PR TITLE
add cf 610e, 2192d, and 2200f solutions

### DIFF
--- a/src/codeforces/set0/set6/set610/set610/e/problem.md
+++ b/src/codeforces/set0/set6/set610/set610/e/problem.md
@@ -1,0 +1,303 @@
+# Problem
+
+You are given a string `s` of length `n`, consisting of the first `k` lowercase English letters.
+
+We define a `c`-repeat of some string `q` as a string consisting of `c` copies of `q`. For example, string `"acbacbacbacb"` is a `4`-repeat of string `"acb"`.
+
+String `a` contains string `b` as a subsequence if `b` can be obtained from `a` by erasing some symbols.
+
+Let `p` be a permutation of the first `k` lowercase English letters. Define `d(p)` as the smallest integer such that a `d(p)`-repeat of string `p` contains string `s` as a subsequence.
+
+There are `m` operations of two types applied to `s` in order:
+
+- `1 l r c`: replace all characters at positions from `l` to `r` by character `c`.
+- `2 p`: for the given permutation `p` of the first `k` lowercase English letters, find `d(p)`.
+
+Your task is to output answers for all operations of the second type.
+
+## Input
+
+The first line contains three integers `n`, `m`, and `k` (`1 <= n <= 200000`, `1 <= m <= 20000`, `1 <= k <= 10`) — the length of `s`, the number of operations, and the alphabet size.
+
+The second line contains string `s`.
+
+Each of the next `m` lines describes one operation:
+
+- Type `1`: `1 l r c` (`1 <= l <= r <= n`, `c` is one of the first `k` lowercase English letters).
+- Type `2`: `2 p`, where `p` is a permutation of the first `k` lowercase English letters.
+
+## Output
+
+For each query of the second type, output the value of function `d(p)`.
+
+## Example
+
+**Input**
+
+```text
+7 4 3
+abacaba
+1 3 5 b
+2 abc
+1 4 4 c
+2 cba
+```
+
+**Output**
+
+```text
+6
+5
+```
+
+## Note
+
+After the first operation, string `s` becomes `abbbbba`.
+
+In the second operation, the answer is `6`-repeat of `abc`:
+`ABcaBcaBcaBcaBcAbc`.
+
+After the third operation, string `s` becomes `abbcbba`.
+
+In the fourth operation, the answer is `5`-repeat of `cba`:
+`cbAcBacBaCBacBA`.
+
+Uppercase letters denote occurrences of symbols from string `s`.
+
+## Editorial
+
+### 1. Reduce a query to adjacent pairs
+
+For a fixed permutation `p`, imagine matching `s` inside:
+
+```text
+pppppp...
+```
+
+Let `pos[x]` be the index of character `x` inside `p`.
+
+Suppose the previous matched character is `x = s[i-1]`, and the next character is `y = s[i]`.
+
+- If `pos[x] < pos[y]`, then after matching `x`, `y` still appears later in the same copy of `p`.
+- If `pos[x] >= pos[y]`, then `y` cannot be matched in the same copy anymore, so the matching must move to the next copy of `p`.
+
+The first character always needs the first copy. After that, every adjacent pair that goes "backward" or stays at the same position starts one more copy.
+
+Therefore:
+
+```text
+d(p) = 1 + count of adjacent pairs (x, y) in s where pos[x] >= pos[y]
+```
+
+Example after the first sample update:
+
+```text
+s = abbbbba
+p = abc
+pos[a]=0, pos[b]=1, pos[c]=2
+```
+
+Adjacent pairs:
+
+```text
+a->b: 0 < 1, same copy
+b->b: 1 >= 1, new copy
+b->b: 1 >= 1, new copy
+b->b: 1 >= 1, new copy
+b->b: 1 >= 1, new copy
+b->a: 1 >= 0, new copy
+```
+
+There are `5` bad adjacent pairs, so `d(p) = 1 + 5 = 6`.
+
+This means the real information needed for any query is only:
+
+```text
+cnt[i][j] = number of adjacent pairs i -> j in the current string
+```
+
+Then query `p` is:
+
+```text
+answer = 1 + sum cnt[i][j] over all i, j with pos[i] >= pos[j]
+```
+
+Since `k <= 10`, this summation is only `O(k^2)`.
+
+### 2. Why direct simulation is too slow
+
+The naive approach would be:
+
+- For type `1`, update all positions in `[l, r]`.
+- For type `2`, scan `s` from left to right while keeping a pointer in permutation `p`.
+
+Both can take `O(n)`. With `n = 200000` and `m = 20000`, this is too slow.
+
+We need to maintain the adjacent-pair counts under range assignment.
+
+### 3. Aggregate for a substring
+
+For any contiguous piece of the current string, store:
+
+- `first`: its first character;
+- `last`: its last character;
+- `cnt[i][j]`: number of adjacent pairs `i -> j` fully inside that piece.
+
+If two neighboring pieces `A` and `B` are joined, the new aggregate is:
+
+```text
+cnt = A.cnt + B.cnt
+cnt[A.last][B.first] += 1
+first = A.first
+last = B.last
+```
+
+The extra pair is the single boundary pair between the last character of `A` and the first character of `B`.
+
+For a uniform run `[l, r]` filled with character `c`, the aggregate is:
+
+```text
+first = c
+last = c
+cnt[c][c] = r - l
+```
+
+There are `r-l+1` characters in the run, so there are `r-l` adjacent pairs inside it.
+
+### 4. Why not a dense segment tree
+
+A segment tree can store this aggregate at every node and support range assignment with lazy propagation.
+
+However, this implementation must fit Codeforces memory limits. A dense segment tree needs about `4*n` nodes. Each node would store a `10 x 10` matrix. In Go, using `int` for those counts makes this too large when `n = 200000`:
+
+```text
+4 * 200000 nodes * 100 ints per node
+```
+
+That is already hundreds of megabytes before pointers, tags, and runtime overhead.
+
+### 5. Run-based treap
+
+The submitted code instead stores the string as ordered runs of equal characters.
+
+Each treap node represents one interval:
+
+```text
+[l, r] filled with character c
+```
+
+The treap is ordered by position. Its in-order traversal gives the current runs from left to right.
+
+Each node stores the aggregate for its whole subtree:
+
+- `first`, `last`;
+- flattened `cnt[10*10]`, using `int32`;
+- random priority `pri`;
+- left and right children.
+
+`int32` is enough because every count is at most `n-1 <= 199999`.
+
+### 6. Recomputing one treap node
+
+The subtree represented by a node is:
+
+```text
+left subtree + current run + right subtree
+```
+
+So `pull(node)` rebuilds the aggregate in that order.
+
+When adding the next piece, if there was a previous piece, add the crossing pair:
+
+```text
+cnt[previous_last][next_first] += 1
+```
+
+Then add the next piece's internal matrix and update the current last character.
+
+This is the same merge rule as the substring aggregate, applied to up to three pieces.
+
+### 7. Split by position
+
+`split(root, pos)` returns:
+
+```text
+left:  all runs strictly before pos
+right: all runs starting at pos or after
+```
+
+If `pos` is outside the current root run, recurse into the left or right child.
+
+If `pos` falls inside a run `[l, r]`, split that run into:
+
+```text
+[l, pos-1] and [pos, r]
+```
+
+Then merge the old children around those new run nodes. This preserves order and keeps every node as a uniform run.
+
+The code may create zero-length boundary nodes if called exactly at a run boundary, but the earlier cases avoid that:
+
+- `pos <= root.l` goes left without splitting the run;
+- `pos > root.r` goes right without splitting the run;
+- only `root.l < pos <= root.r` reaches the internal split.
+
+### 8. Range assignment
+
+For operation:
+
+```text
+1 l r c
+```
+
+Convert to zero-based positions and split twice:
+
+```text
+A, B = split(root, l)
+B, C = split(B, r+1)
+```
+
+Now:
+
+- `A` is before the update interval;
+- `B` is the old content of `[l, r]`;
+- `C` is after the update interval.
+
+Discard `B`, create one new run `[l, r]` with character `c`, and merge:
+
+```text
+root = merge(merge(A, newRun), C)
+```
+
+All affected aggregates are rebuilt by `pull` while merging.
+
+### 9. Query
+
+For operation:
+
+```text
+2 p
+```
+
+Build `pos[]` for the permutation. The root already stores all adjacent-pair counts for the whole string, so compute:
+
+```text
+answer = 1
+for i in alphabet:
+    for j in alphabet:
+        if pos[i] >= pos[j]:
+            answer += root.cnt[i][j]
+```
+
+This exactly matches the formula from Section 1.
+
+### 10. Complexity
+
+Let `R` be the current number of treap nodes.
+
+- Building from the initial string creates one node per maximal equal-character run.
+- Type `1` does two splits and two merges, so it costs expected `O(k^2 log R)`.
+- Type `2` costs `O(k^2)`.
+- Memory is `O(k^2 * R)`.
+
+The important practical difference from the dense segment tree is that `R` is based on runs created by updates, not `4*n` fixed tree nodes, and the matrix uses `int32` instead of Go `int`.

--- a/src/codeforces/set0/set6/set610/set610/e/solution.go
+++ b/src/codeforces/set0/set6/set610/set610/e/solution.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	res := solve(reader)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	for _, x := range res {
+		fmt.Fprintln(writer, x)
+	}
+}
+
+type state struct {
+	first int
+	last  int
+	cnt   [][]int
+}
+
+func newMatrix(k int) [][]int {
+	m := make([][]int, k)
+	for i := range k {
+		m[i] = make([]int, k)
+	}
+	return m
+}
+
+func mergeState(a state, b state, k int) state {
+	c := newMatrix(k)
+
+	for i := range k {
+		for j := range k {
+			c[i][j] = a.cnt[i][j] + b.cnt[i][j]
+		}
+	}
+	c[a.last][b.first]++
+	return state{
+		first: a.first,
+		last:  b.last,
+		cnt:   c,
+	}
+}
+
+func solve(reader *bufio.Reader) []int {
+	var n, m, k int
+	fmt.Fscan(reader, &n, &m, &k)
+
+	var s string
+	fmt.Fscan(reader, &s)
+
+	tr := make([]state, 4*n)
+	lazy := make([]int, 4*n)
+
+	merge := func(a state, b state, c *state) {
+		for u := range k {
+			for v := range k {
+				c.cnt[u][v] = a.cnt[u][v] + b.cnt[u][v]
+			}
+		}
+		c.first = a.first
+		c.last = b.last
+		c.cnt[a.last][b.first]++
+	}
+
+	var build func(i int, l int, r int)
+	build = func(i int, l int, r int) {
+		lazy[i] = -1
+		if l == r {
+			tr[i] = state{
+				first: int(s[l] - 'a'),
+				last:  int(s[l] - 'a'),
+				cnt:   newMatrix(k),
+			}
+			return
+		}
+		mid := (l + r) / 2
+		build(i*2+1, l, mid)
+		build(i*2+2, mid+1, r)
+		tr[i].cnt = newMatrix(k)
+		merge(tr[i*2+1], tr[i*2+2], &tr[i])
+	}
+
+	build(0, 0, n-1)
+
+	apply := func(i int, l int, r int, c int) {
+		for u := range k {
+			for v := range k {
+				tr[i].cnt[u][v] = 0
+			}
+		}
+		tr[i].first = c
+		tr[i].last = c
+		tr[i].cnt[c][c] = r - l
+		lazy[i] = c
+	}
+
+	push := func(i int, l int, r int) {
+		if lazy[i] != -1 {
+			mid := (l + r) / 2
+			apply(i*2+1, l, mid, lazy[i])
+			apply(i*2+2, mid+1, r, lazy[i])
+			lazy[i] = -1
+		}
+	}
+
+	var update func(i int, l int, r int, L int, R int, c int)
+	update = func(i int, l int, r int, L int, R int, c int) {
+		if l == L && r == R {
+			apply(i, l, r, c)
+			return
+		}
+		push(i, l, r)
+		mid := (l + r) / 2
+		if L <= mid {
+			update(i*2+1, l, mid, L, min(mid, R), c)
+		}
+		if mid < R {
+			update(i*2+2, mid+1, r, max(mid+1, L), R, c)
+		}
+		merge(tr[i*2+1], tr[i*2+2], &tr[i])
+	}
+
+	pos := make([]int, k)
+	find := func(p string) int {
+		for i, x := range p {
+			pos[int(x-'a')] = i
+		}
+		var sum int
+		for i := range k {
+			for j := range k {
+				c := tr[0].cnt[i][j]
+				if pos[i] >= pos[j] {
+					sum += c
+				}
+			}
+		}
+		return sum + 1
+	}
+
+	var ans []int
+
+	for range m {
+		var tp int
+		fmt.Fscan(reader, &tp)
+		if tp == 1 {
+			var l, r int
+			var c string
+			fmt.Fscan(reader, &l, &r, &c)
+			update(0, 0, n-1, l-1, r-1, int(c[0]-'a'))
+		} else {
+			var p string
+			fmt.Fscan(reader, &p)
+			ans = append(ans, find(p))
+		}
+	}
+
+	return ans
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n, m, k int
+	fmt.Fscan(reader, &n, &m, &k)
+
+	var s string
+	fmt.Fscan(reader, &s)
+
+	st := NewSegTree([]byte(s), k)
+	var res []int
+	for ; m > 0; m-- {
+		var tp int
+		fmt.Fscan(reader, &tp)
+		if tp == 1 {
+			var l, r int
+			var c string
+			fmt.Fscan(reader, &l, &r, &c)
+			st.Update(l-1, r-1, int(c[0]-'a'))
+		} else {
+			var p string
+			fmt.Fscan(reader, &p)
+			res = append(res, st.Query([]byte(p)))
+		}
+	}
+	return res
+}
+
+const maxAlphabet = 10
+
+type Node struct {
+	l     int
+	r     int
+	c     int
+	pri   uint32
+	left  *Node
+	right *Node
+	first int
+	last  int
+	cnt   [maxAlphabet * maxAlphabet]int32
+}
+
+type SegTree struct {
+	k    int
+	root *Node
+	seed uint32
+}
+
+func NewSegTree(s []byte, k int) *SegTree {
+	st := &SegTree{
+		k:    k,
+		seed: 1,
+	}
+	for l := 0; l < len(s); {
+		r := l
+		for r+1 < len(s) && s[r+1] == s[l] {
+			r++
+		}
+		st.root = merge(st.root, st.newNode(l, r, int(s[l]-'a')))
+		l = r + 1
+	}
+	return st
+}
+
+func (st *SegTree) newNode(l int, r int, c int) *Node {
+	node := &Node{
+		l:     l,
+		r:     r,
+		c:     c,
+		pri:   st.nextRand(),
+		first: c,
+		last:  c,
+	}
+	node.cnt[c*maxAlphabet+c] = int32(r - l)
+	return node
+}
+
+func (st *SegTree) nextRand() uint32 {
+	st.seed = st.seed*1664525 + 1013904223
+	return st.seed
+}
+
+func (st *SegTree) Update(l int, r int, c int) {
+	var mid, right *Node
+	st.root, mid = st.split(st.root, l)
+	mid, right = st.split(mid, r+1)
+	st.root = merge(merge(st.root, st.newNode(l, r, c)), right)
+}
+
+func (st *SegTree) Query(p []byte) int {
+	pos := make([]int, st.k)
+	for i, x := range p {
+		pos[x-'a'] = i
+	}
+	res := 1
+	for i := 0; i < st.k; i++ {
+		for j := 0; j < st.k; j++ {
+			if pos[i] >= pos[j] {
+				res += int(st.root.cnt[i*maxAlphabet+j])
+			}
+		}
+	}
+	return res
+}
+
+func (st *SegTree) split(root *Node, pos int) (*Node, *Node) {
+	if root == nil {
+		return nil, nil
+	}
+	if pos <= root.l {
+		a, b := st.split(root.left, pos)
+		root.left = b
+		pull(root)
+		return a, root
+	}
+	if pos > root.r {
+		a, b := st.split(root.right, pos)
+		root.right = a
+		pull(root)
+		return root, b
+	}
+
+	left := st.newNode(root.l, pos-1, root.c)
+	right := st.newNode(pos, root.r, root.c)
+	return merge(root.left, left), merge(right, root.right)
+}
+
+func merge(a *Node, b *Node) *Node {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.pri < b.pri {
+		a.right = merge(a.right, b)
+		pull(a)
+		return a
+	}
+	b.left = merge(a, b.left)
+	pull(b)
+	return b
+}
+
+func pull(node *Node) {
+	for i := range node.cnt {
+		node.cnt[i] = 0
+	}
+	has := false
+	add := func(first int, last int, cnt [maxAlphabet * maxAlphabet]int32) {
+		if !has {
+			node.first = first
+			has = true
+		} else {
+			node.cnt[node.last*maxAlphabet+first]++
+		}
+		for i, v := range cnt {
+			node.cnt[i] += v
+		}
+		node.last = last
+	}
+	if node.left != nil {
+		add(node.left.first, node.left.last, node.left.cnt)
+	}
+	if !has {
+		node.first = node.c
+		has = true
+	} else {
+		node.cnt[node.last*maxAlphabet+node.c]++
+	}
+	node.cnt[node.c*maxAlphabet+node.c] += int32(node.r - node.l)
+	node.last = node.c
+	if node.right != nil {
+		add(node.right.first, node.right.last, node.right.cnt)
+	}
+}

--- a/src/codeforces/set0/set6/set610/set610/e/solution_test.go
+++ b/src/codeforces/set0/set6/set610/set610/e/solution_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := solve(reader)
+	if !reflect.DeepEqual(res, expect) {
+		t.Fatalf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `7 4 3
+abacaba
+1 3 5 b
+2 abc
+1 4 4 c
+2 cba
+`
+	expect := []int{6, 5}
+	runSample(t, s, expect)
+}
+
+func TestRandom(t *testing.T) {
+	rng := rand.New(rand.NewSource(610))
+	for tc := 0; tc < 1000; tc++ {
+		n := rng.Intn(12) + 1
+		k := rng.Intn(5) + 1
+		s := make([]byte, n)
+		for i := range s {
+			s[i] = byte(rng.Intn(k)) + 'a'
+		}
+		st := NewSegTree(s, k)
+		for it := 0; it < 100; it++ {
+			if rng.Intn(2) == 0 {
+				l := rng.Intn(n)
+				r := rng.Intn(n-l) + l
+				c := byte(rng.Intn(k)) + 'a'
+				for i := l; i <= r; i++ {
+					s[i] = c
+				}
+				st.Update(l, r, int(c-'a'))
+			} else {
+				p := rng.Perm(k)
+				perm := make([]byte, k)
+				for i, x := range p {
+					perm[i] = byte(x) + 'a'
+				}
+				got := st.Query(perm)
+				want := brute(s, perm)
+				if got != want {
+					t.Fatalf("tc %d it %d: s=%s perm=%s, expect %d, got %d", tc, it, s, perm, want, got)
+				}
+			}
+		}
+	}
+}
+
+
+func brute(s []byte, perm []byte) int {
+	pos := make([]int, len(perm))
+	for i, x := range perm {
+		pos[x-'a'] = i
+	}
+	res := 1
+	for i := 1; i < len(s); i++ {
+		if pos[s[i-1]-'a'] >= pos[s[i]-'a'] {
+			res++
+		}
+	}
+	return res
+}

--- a/src/codeforces/set2/set21/set219/set2192/d/problem.md
+++ b/src/codeforces/set2/set21/set219/set2192/d/problem.md
@@ -1,0 +1,115 @@
+# Problem
+
+For a tree `T` with root `r`, where each node `u` has a value `au`, the **cost** of the tree is defined as:
+
+`sum over u in T of (au * d(r, u))`
+
+where `d(r, u)` is the number of edges on the shortest path from `r` to `u` in `T`.
+
+You are given a tree with `n` nodes, rooted at node `1`. Each node `i` has value `ai`.
+
+For each `r` from `1` to `n`, solve the following **independently**:
+
+Consider the **subtree of node `r`** with respect to root `1`. Formally, it is the tree consisting of all nodes `u` such that the shortest path from `1` to `u` contains `r`.
+
+Find the **maximum** cost of this subtree after performing **at most one** operation of the following type:
+
+- Choose any node `u` with `u ≠ r`.
+- Remove the edge from `u` to its parent `p` (the unique node with `d(u, p) = 1` and `d(u, r) = d(p, r) + 1`).
+- Add an edge from `u` to any node `v` that remains reachable from `r` in the current subtree.
+
+After the operation, the graph must remain a tree.
+
+## Input
+
+The first line contains integer `t` (`1 ≤ t ≤ 10^4`) — the number of test cases.
+
+Each test case:
+
+- First line: integer `n` (`1 ≤ n ≤ 2 * 10^5`) — number of nodes.
+- Second line: `n` integers `a1, a2, ..., an` (`1 ≤ ai ≤ 2 * 10^5`).
+- Next `n - 1` lines: two integers `u` and `v` (`1 ≤ u, v ≤ n`) — an edge of the tree.
+
+It is guaranteed that the edges form a tree.
+
+The sum of `n` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, print `n` integers — the answers for `r = 1, 2, ..., n`, in order.
+
+## Example
+
+**Input**
+
+```text
+3
+5
+1 3 2 1 2
+1 2
+2 3
+3 4
+3 5
+7
+1 2 3 1 3 2 1
+1 2
+2 3
+3 4
+4 5
+4 6
+3 7
+5
+5 4 3 2 1
+1 2
+2 3
+3 4
+4 5
+```
+
+**Output**
+
+```text
+18 10 5 0 0
+40 28 18 8 0 0 0
+20 10 4 1 0
+```
+
+## Note
+
+In the first test case, for `r = 1`, it is optimal to choose `u = 5` and `v = 4`. The cost becomes:
+
+`1 * 0 + 3 * 1 + 2 * 2 + 1 * 3 + 2 * 4 = 18`
+
+For `r = 4`, the subtree has only one node, so no operation is possible and the cost is `0`.
+
+## key insights
+
+1. The code runs one DFS on the global tree rooted at node `1` (index `0`). For each node `u` it computes values that are combined into the printed answer for `r = u + 1` as `fp[u] + dp[u]`.
+
+2. **Base contribution (`fp`)**  
+   While DFSing, it maintains:
+   - `sum[u]` — total `a` over the subtree of `u` (with respect to root `1`),
+   - `dep[u]` — depth from root `1`,
+   - `fp[u]` — accumulates the weighted depth sum for the subtree using the recurrence  
+     `fp[u] += fp[v] + sum[v]` over children `v` (equivalently: extending the subtree through edge `(u, v)` adds `sum[v]` to the depth contribution of everything below `v`).
+
+3. **One-operation extra gain (`dp`)**  
+   The operation “rehang one child subtree” is modeled as attaching a child subtree `v` under the **deepest** part of a different child branch to maximize depth gain.
+
+4. For each node `u`, it tracks the two child subtrees with the largest `most_dep` (deepest node depth inside that child subtree):
+   - `best[0]` — child with maximum `most_dep`,
+   - `best[1]` — second maximum.
+
+5. For each child `v` of `u`, it evaluates a candidate gain:
+   - if `v` is not `best[0]`, hang `v` under the deepest branch of `best[0]`:
+     - `sum[v] * (most_dep[best[0]] - dep[v] + 1)`
+   - else hang `v` under `best[1]` similarly:
+     - `sum[v] * (most_dep[best[1]] - dep[v] + 1)`
+
+   Then `dp[u] = max over children of (dp[v], and these candidate tmp values)`.
+
+6. If `u` has fewer than two nontrivial child branches (`best[1] < 0`), no cross-branch rehang is possible at `u`, so the extra gain from this pattern is `0` at that node.
+
+7. Final per-node output is `fp[i] + dp[i]` for all `i` (answers for `r = 1..n` in order).
+
+8. Complexity: `O(n)` per test case (one DFS, constant work per edge), which matches `sum n ≤ 2 * 10^5`.

--- a/src/codeforces/set2/set21/set219/set2192/d/solution.go
+++ b/src/codeforces/set2/set21/set219/set2192/d/solution.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	edges := make([][]int, n-1)
+	for i := range n - 1 {
+		edges[i] = make([]int, 2)
+		fmt.Fscan(reader, &edges[i][0], &edges[i][1])
+	}
+	return solve(a, edges)
+}
+
+func solve(a []int, edges [][]int) []int {
+	n := len(a)
+	adj := make([][]int, n)
+
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+
+	// dp[u] = 子树u种最大的收获
+	// 把它的一个子树v, 移动到另一棵子树w的最底端
+	// sum(v) * (most_dep[w] - dep[v])
+	fp := make([]int, n)
+	dp := make([]int, n)
+	dep := make([]int, n)
+	most_dep := make([]int, n)
+	sum := make([]int, n)
+
+	var dfs func(p int, u int)
+	dfs = func(p int, u int) {
+		sum[u] = a[u]
+		most_dep[u] = dep[u]
+
+		best := []int{-1, -1}
+
+		for _, v := range adj[u] {
+			if p != v {
+				dep[v] = dep[u] + 1
+				dfs(u, v)
+				sum[u] += sum[v]
+				fp[u] += fp[v] + sum[v]
+				most_dep[u] = max(most_dep[u], most_dep[v])
+				if best[0] < 0 || most_dep[v] >= most_dep[best[0]] {
+					best[1] = best[0]
+					best[0] = v
+				} else if best[1] < 0 || most_dep[v] >= most_dep[best[1]] {
+					best[1] = v
+				}
+				dp[u] = max(dp[u], dp[v])
+			}
+		}
+		if best[1] < 0 {
+			// 只有最多一个子树
+			return
+		}
+		for _, v := range adj[u] {
+			if p != v {
+				if v != best[0] {
+					tmp := sum[v] * (most_dep[best[0]] - dep[v] + 1)
+					dp[u] = max(dp[u], tmp)
+				} else {
+					tmp := sum[v] * (most_dep[best[1]] - dep[v] + 1)
+					dp[u] = max(dp[u], tmp)
+				}
+			}
+		}
+	}
+
+	dfs(-1, 0)
+
+	for i := range n {
+		fp[i] += dp[i]
+	}
+
+	return fp
+}

--- a/src/codeforces/set2/set21/set219/set2192/d/solution_test.go
+++ b/src/codeforces/set2/set21/set219/set2192/d/solution_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `5
+1 3 2 1 2
+1 2
+2 3
+3 4
+3 5`
+	expect := []int{18, 10, 5, 0, 0}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `7
+1 2 3 1 3 2 1
+1 2
+2 3
+3 4
+4 5
+4 6
+3 7`
+	expect := []int{40, 28, 18, 8, 0, 0, 0}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5
+5 4 3 2 1
+1 2
+2 3
+3 4
+4 5`
+	expect := []int{20, 10, 4, 1, 0}
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set22/set220/set2200/f/problem.md
+++ b/src/codeforces/set2/set22/set220/set2200/f/problem.md
@@ -1,0 +1,91 @@
+# Problem
+
+Bessie needs to produce as much energy as possible in her nuclear reactor. She has `n` different particles.
+
+Each particle is defined by two integers `x` and `y`. The particle generates `x` units of energy but has a reactivity `y`, meaning that it can only exist together with at most `y` other particles in the reactor. Formally, if this particle is chosen to generate energy, then at most `y` particles (other than itself) can also be chosen to generate energy.
+
+Bessie must choose a subset of particles that satisfy this constraint to generate energy. The amount of energy that she generates is equal to the sum of the energies of the particles in the subset.
+
+There is a shop with `m` particles. Bessie can buy exactly one particle from the shop. For each particle in the shop, determine the maximum total energy that Bessie would be able to produce if she were to buy only that particle from the shop. Bessie is not required to use the particle that is purchased from the shop.
+
+## Input
+
+The first line contains a single integer `t` (`1 ≤ t ≤ 10^4`) — the number of test cases.
+
+The first line of each test case contains two integers `n` and `m` (`1 ≤ n, m ≤ 2 * 10^5`) — the number of particles that Bessie has and the number of particles in the shop, respectively.
+
+The `i`-th of the next `n` lines contains two integers `x` and `y` (`1 ≤ x ≤ 10^9`, `0 ≤ y ≤ n`) — the energy and reactivity of Bessie's `i`-th particle.
+
+The `j`-th of the next `m` lines contains two integers `x` and `y` (`1 ≤ x ≤ 10^9`, `0 ≤ y ≤ n`) — the energy and reactivity of the shop's `j`-th particle.
+
+It is guaranteed that the sum of `n` over all test cases and the sum of `m` over all test cases do not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, print `m` integers. The `i`-th integer should be the maximum total energy that Bessie can produce if she purchases the `i`-th particle from the shop.
+
+## Example
+
+**Input**
+
+```text
+3
+3 3
+67 0
+6 1
+7 1
+1 0
+100 0
+62 1
+2 1
+2 2
+4 2
+3 1
+1 2
+6 1
+7 0
+8 1
+```
+
+**Output**
+
+```text
+67 100 69
+7
+7 14
+```
+
+## Note
+
+In the first test case:
+
+- If Bessie buys particle `4`, then it is optimal for her to only use particle `1` and generate `67` energy units.
+- If she buys particle `5`, then she should only use particle `5`, which generates `100` energy units.
+- If she buys particle `6`, then she should use particles `3` and `6`, for a total of `69` energy units.
+
+## key insights
+
+1. For a fixed chosen subset size `k`, every selected particle must satisfy `y >= k - 1`. So among particles with `y >= k - 1`, the best valid subset is simply the top-`k` values of `x`.
+
+2. The code processes original particles offline by decreasing `y`:
+   - `ys[y]` stores all energies `x` whose reactivity is exactly `y`.
+   - While iterating `y = n..0`, it inserts all `ys[y]` into a structure that represents all particles with reactivity at least current `y`.
+
+3. To get "sum of largest `k` energies" fast, `Tree` is a segment tree over compressed `x` values:
+   - each node stores `cnt` (how many particles in this value range) and `val` (sum of energies),
+   - `GetBest(k)` walks from large `x` to small `x` and returns the sum of the largest `k` inserted energies.
+
+4. During the same sweep, the solution builds:
+   - `best = max over y of GetBest(y + 1)` (best answer using only original particles),
+   - `dp[y] = GetBest(y)` (best sum for selecting exactly `y` original particles from those with reactivity at least `y`).
+
+5. For a shop particle `(x, y)`, if it is used, we can add at most `y` other particles, each needing reactivity at least `y`. So candidate value is:
+   - `x + dp.Get(0, y + 1)` where `dp.Get(0, y + 1)` is the maximum of `dp[k]` for `0 <= k <= y`.
+
+6. Final answer per shop particle:
+   - `max(best, x + max_{0<=k<=y} dp[k])`,
+   which also covers the case "buy but do not use it".
+
+7. Complexity per test case:
+   - `O((n + m) log n)` time (segment tree operations),
+   - `O(n)` extra memory (plus compressed-value tree).

--- a/src/codeforces/set2/set22/set220/set2200/f/solution.go
+++ b/src/codeforces/set2/set22/set220/set2200/f/solution.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	particles := make([][]int, n)
+	for i := range n {
+		var x, y int
+		fmt.Fscan(reader, &x, &y)
+		particles[i] = []int{x, y}
+	}
+	shop := make([][]int, m)
+	for i := range m {
+		var x, y int
+		fmt.Fscan(reader, &x, &y)
+		shop[i] = []int{x, y}
+	}
+	return solve(particles, shop)
+}
+
+func solve(particles [][]int, shop [][]int) []int {
+
+	n := len(particles)
+	var xs []int
+
+	ys := make([][]int, n+1)
+
+	for _, cur := range particles {
+		xs = append(xs, cur[0])
+		ys[cur[1]] = append(ys[cur[1]], cur[0])
+	}
+	slices.Sort(xs)
+	xs = slices.Compact(xs)
+
+	tr := NewTree(len(xs))
+
+	dp := make(SegTree, 2*(n+1))
+
+	var best int
+	for y := n; y >= 0; y-- {
+		for _, x := range ys[y] {
+			i := sort.SearchInts(xs, x)
+			tr.Update(i, x)
+		}
+		best = max(best, tr.GetBest(y+1))
+		dp.Update(y, tr.GetBest(y))
+	}
+
+	ans := make([]int, len(shop))
+	for i, cur := range shop {
+		x, y := cur[0], cur[1]
+		ans[i] = max(best, x+dp.Get(0, y+1))
+	}
+
+	return ans
+}
+
+type SegTree []int
+
+func (t SegTree) Update(p int, v int) {
+	p += len(t) / 2
+	t[p] = max(t[p], v)
+	for p > 1 {
+		t[p>>1] = max(t[p], t[p^1])
+		p >>= 1
+	}
+}
+
+func (t SegTree) Get(l int, r int) int {
+	n := len(t) / 2
+	l += n
+	r += n
+	var res int
+	for l < r {
+		if l&1 == 1 {
+			res = max(res, t[l])
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			res = max(res, t[r])
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+type Tree struct {
+	cnt []int
+	val []int
+	sz  int
+}
+
+func NewTree(n int) *Tree {
+	cnt := make([]int, 4*n)
+	val := make([]int, 4*n)
+	return &Tree{cnt, val, n}
+}
+
+func (t *Tree) Update(p int, v int) {
+	var f func(i int, l int, r int)
+	f = func(i int, l int, r int) {
+		if l == r {
+			t.cnt[i]++
+			t.val[i] += v
+			return
+		}
+		mid := (l + r) >> 1
+		if p <= mid {
+			f(2*i+1, l, mid)
+		} else {
+			f(2*i+2, mid+1, r)
+		}
+		t.cnt[i] = t.cnt[2*i+1] + t.cnt[2*i+2]
+		t.val[i] = t.val[2*i+1] + t.val[2*i+2]
+	}
+	f(0, 0, t.sz-1)
+}
+
+func (t *Tree) GetBest(k int) int {
+	if k == 0 {
+		return 0
+	}
+	if k >= t.cnt[0] {
+		return t.val[0]
+	}
+
+	var f func(i int, l int, r int, k int) int
+	f = func(i int, l int, r int, k int) int {
+		if l == r {
+			return t.val[i] / t.cnt[i] * k
+		}
+		mid := (l + r) >> 1
+		if t.cnt[2*i+2] >= k {
+			return f(2*i+2, mid+1, r, k)
+		}
+		return t.val[2*i+2] + f(2*i+1, l, mid, k-t.cnt[2*i+2])
+	}
+	return f(0, 0, t.sz-1, k)
+}

--- a/src/codeforces/set2/set22/set220/set2200/f/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2200/f/solution_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	for i, v := range expect {
+		if res[i] != v {
+			t.Errorf("Sample expect %v, but got %v, differ at %d", expect, res, i)
+		}
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3 3
+67 0
+6 1
+7 1
+1 0
+100 0
+62 1
+`
+	expect := []int{67, 100, 69}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `2 1
+2 2
+4 2
+3 1
+`
+	expect := []int{7}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `1 2
+6 1
+7 0
+8 1
+`
+	expect := []int{7, 14}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `8 10
+643444063 7
+208999612 5
+148423326 0
+543584678 3
+330940797 7
+155699366 3
+384886181 3
+382481223 3
+756968649 1
+6107718 4
+939210119 3
+409114343 0
+706144299 1
+418198997 2
+959553978 2
+968610514 5
+990506063 2
+817619952 3
+`
+	expect := []int{1954396145, 1954396145, 2511125041, 1954396145, 1954396145, 1954396145, 2146582719, 2540525436, 2177534804, 2389534874}
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- add Codeforces 610E solution, tests, and a formatted problem statement with editorial notes
- add Codeforces 2192D solution/tests and format/annotate its problem statement with key insights
- add Codeforces 2200F solution/tests and format/annotate its problem statement with key insights

## Test plan
- [x] Go unit tests added for 610E, 2192D, and 2200F
- [ ] Run `go test ./...` locally
- [ ] Spot-check sample inputs against expected outputs

Made with [Cursor](https://cursor.com)