### PR TITLE
add leetcode 3908-3915 solutions

### DIFF
--- a/src/leetcode/set1000/set3000/set3900/set3900/p3908/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3900/p3908/solution.go
@@ -1,0 +1,12 @@
+package p3908
+
+func validDigit(n int, x int) bool {
+	found := false
+	for n >= 10 {
+		if n%10 == x {
+			found = true
+		}
+		n /= 10
+	}
+	return n != x && found
+}

--- a/src/leetcode/set1000/set3000/set3900/set3900/p3909/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3900/p3909/solution.go
@@ -1,0 +1,28 @@
+package p3909
+
+func compareBitonicSums(nums []int) int {
+	peek := 0
+	n := len(nums)
+	for i := 1; i < n; i++ {
+		if nums[i] > nums[i-1] && (i == n-1 || nums[i] > nums[i+1]) {
+			peek = i
+			break
+		}
+	}
+	var sum1 int
+	for i := 0; i <= peek; i++ {
+		sum1 += nums[i]
+	}
+	var sum2 int
+	for i := peek; i < n; i++ {
+		sum2 += nums[i]
+	}
+	if sum1 > sum2 {
+		return 0
+	}
+	if sum1 < sum2 {
+		return 1
+	}
+
+	return -1
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3910/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3910/solution.go
@@ -1,0 +1,86 @@
+package p3910
+
+func evenSumSubgraphs(nums []int, edges [][]int) int {
+	n := len(nums)
+	set := NewDSU(n)
+
+	var res int
+
+	for mask := 1; mask < (1 << n); mask++ {
+		var sum int
+		first := -1
+		for i := range n {
+			if (mask>>i)&1 == 1 {
+				sum += nums[i]
+				first = i
+			}
+		}
+		if sum%2 == 1 {
+			continue
+		}
+		for _, e := range edges {
+			u, v := e[0], e[1]
+			if (mask>>u)&1 == 1 && (mask>>v)&1 == 1 {
+				set.Union(u, v)
+			}
+		}
+		ok := true
+		for i := range n {
+			if (mask>>i)&1 == 1 {
+				if set.Find(i) != set.Find(first) {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			res++
+		}
+		set.Reset()
+	}
+	return res
+}
+
+type DSU struct {
+	arr []int
+	cnt []int
+}
+
+func NewDSU(n int) *DSU {
+	arr := make([]int, n)
+	cnt := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = i
+		cnt[i] = 1
+	}
+	return &DSU{arr, cnt}
+}
+
+func (this *DSU) Find(x int) int {
+	if this.arr[x] != x {
+		this.arr[x] = this.Find(this.arr[x])
+	}
+	return this.arr[x]
+}
+
+func (this *DSU) Union(x int, y int) bool {
+	px := this.Find(x)
+	py := this.Find(y)
+
+	if px == py {
+		return false
+	}
+	if this.cnt[px] < this.cnt[py] {
+		px, py = py, px
+	}
+	this.cnt[px] += this.cnt[py]
+	this.arr[py] = px
+	return true
+}
+
+func (this *DSU) Reset() {
+	for i := range this.arr {
+		this.arr[i] = i
+		this.cnt[i] = 1
+	}
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3911/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3911/solution.go
@@ -1,0 +1,43 @@
+package p3911
+
+import "sort"
+
+func kthRemainingInteger(nums []int, queries [][]int) []int {
+	n := len(nums)
+	pref := make([]int, n+1)
+	val := make([]int, n+1)
+
+	for i, v := range nums {
+		val[i+1] = val[i]
+		pref[i+1] = pref[i]
+		if v%2 == 0 {
+			val[i+1] = v
+			pref[i+1]++
+		}
+	}
+	find := func(l int, r int, k int) int {
+		if pref[r+1] == pref[l] {
+			// l...r没有偶数
+			return 2 * k
+		}
+
+		d := sort.Search(r-l+1, func(d int) bool {
+			i := l + d
+			// 到i出现了cnt个偶数
+			// 一共有 val[i+1] / 2 个偶数
+			cnt := pref[i+1] - pref[l]
+			return val[i+1]/2-cnt >= k
+		})
+		i := l + d - 1
+		cnt := val[i+1]/2 - (pref[i+1] - pref[l])
+		return val[i+1] + 2*(k-cnt)
+	}
+
+	ans := make([]int, len(queries))
+
+	for i, cur := range queries {
+		ans[i] = find(cur[0], cur[1], cur[2])
+	}
+
+	return ans
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3911/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3911/solution_test.go
@@ -1,0 +1,34 @@
+package p3911
+
+import (
+	"slices"
+	"testing"
+)
+
+func runSample(t *testing.T, nums []int, queries [][]int, expect []int) {
+	res := kthRemainingInteger(nums, queries)
+	if !slices.Equal(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{1, 4, 7}
+	queries := [][]int{{0, 2, 1}, {1, 1, 2}, {0, 0, 3}}
+	expect := []int{2, 6, 6}
+	runSample(t, nums, queries, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{2, 5, 8}
+	queries := [][]int{{0, 1, 2}, {1, 2, 1}, {0, 2, 4}}
+	expect := []int{6, 2, 12}
+	runSample(t, nums, queries, expect)
+}
+
+func TestSample3(t *testing.T) {
+	nums := []int{3, 6}
+	queries := [][]int{{0, 1, 1}, {1, 1, 3}}
+	expect := []int{2, 8}
+	runSample(t, nums, queries, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3912/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3912/solution.go
@@ -1,0 +1,27 @@
+package p3912
+
+func findValidElements(nums []int) []int {
+	n := len(nums)
+	ok := make([]bool, n)
+	prev := -1
+	for i, v := range nums {
+		if v > prev {
+			ok[i] = true
+		}
+		prev = max(prev, v)
+	}
+	next := -1
+	for i := n - 1; i >= 0; i-- {
+		if nums[i] > next {
+			ok[i] = true
+		}
+		next = max(next, nums[i])
+	}
+	var res []int
+	for i, v := range nums {
+		if ok[i] {
+			res = append(res, v)
+		}
+	}
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3913/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3913/solution.go
@@ -1,0 +1,68 @@
+package p3913
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+)
+
+type data struct {
+	id  int
+	pos int
+	val byte
+}
+
+func sortVowels(s string) string {
+	vowels := "aeiou"
+	var buf []data
+	freq := make([]int, 5)
+	var ww []int
+	first := make([]int, 5)
+	n := len(s)
+
+	for i := n - 1; i >= 0; i-- {
+		j := strings.IndexByte(vowels, s[i])
+		if j >= 0 {
+			buf = append(buf, data{j, i, s[i]})
+			freq[j]++
+			ww = append(ww, i)
+			first[j] = i
+		}
+	}
+
+	var ids []int
+	for i := range 5 {
+		if freq[i] > 0 {
+			ids = append(ids, i)
+		}
+	}
+
+	if len(ids) == 0 {
+		return s
+	}
+
+	slices.SortFunc(ids, func(a int, b int) int {
+		return cmp.Or(freq[b]-freq[a], first[a]-first[b])
+	})
+
+	pos := make([]int, 5)
+	for i, v := range ids {
+		pos[v] = i
+	}
+
+	slices.SortFunc(buf, func(a data, b data) int {
+		if a.id == b.id {
+			return a.pos - b.pos
+		}
+		return pos[a.id] - pos[b.id]
+	})
+
+	slices.Reverse(ww)
+
+	res := []byte(s)
+	for i, j := range ww {
+		res[j] = buf[i].val
+	}
+
+	return string(res)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3913/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3913/solution_test.go
@@ -1,0 +1,22 @@
+package p3913
+
+import "testing"
+
+func runSample(t *testing.T, s string, expect string) {
+	res := sortVowels(s)
+	if res != expect {
+		t.Errorf("Sample expect %s, but got %s", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := "leetcode"
+	expect := "leetcedo"
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := "aeiaaioooa"
+	expect := "aaaaoooiie"
+	runSample(t, s, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3914/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3914/solution.go
@@ -1,0 +1,20 @@
+package p3914
+
+import "slices"
+
+func minOperations(nums []int) int64 {
+	// nums[0] 不能被增加（它增加了，后面的都要增加）
+	var add int
+	n := len(nums)
+	var res int
+	arr := slices.Clone(nums)
+	for i := 1; i < n; i++ {
+		cur := nums[i] + add
+		if cur < arr[i-1] {
+			add += arr[i-1] - cur
+			res += arr[i-1] - cur
+		}
+		arr[i] += add
+	}
+	return int64(res)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3914/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3914/solution_test.go
@@ -1,0 +1,22 @@
+package p3914
+
+import "testing"
+
+func runSample(t *testing.T, nums []int, expect int64) {
+	res := minOperations(nums)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{3, 3, 2, 1}
+	expect := int64(2)
+	runSample(t, nums, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{5, 1, 2, 3}
+	expect := int64(4)
+	runSample(t, nums, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3915/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3915/solution.go
@@ -1,0 +1,77 @@
+package p3915
+
+import (
+	"slices"
+	"sort"
+)
+
+func maxAlternatingSum(nums []int, k int) int64 {
+	// dp[i][0]表示到i为止, 以i为峰时的最大值
+	// dp[i][1] 表示到i为止，以i为谷时的最优解
+	arr := slices.Clone(nums)
+	slices.Sort(arr)
+	arr = slices.Compact(arr)
+	m := len(arr)
+	t1 := make(SegTree, 2*m)
+	t2 := make(SegTree, 2*m)
+
+	n := len(nums)
+	dp := make([][2]int, n)
+
+	for i, v := range nums {
+		if i-k >= 0 {
+			w := nums[i-k]
+			j := sort.SearchInts(arr, w)
+			y := t1.Get(j, j+1)
+			if y < dp[i-k][0] {
+				t1.Update(j, dp[i-k][0])
+			}
+			y = t2.Get(j, j+1)
+			if y < dp[i-k][1] {
+				t2.Update(j, dp[i-k][1])
+			}
+		}
+		j := sort.SearchInts(arr, v)
+		dp[i][0] = t2.Get(0, j) + v
+		dp[i][1] = t1.Get(j+1, m) + v
+	}
+
+	var res int
+	for i := range n {
+		res = max(res, dp[i][0], dp[i][1])
+	}
+
+	return int64(res)
+}
+
+type SegTree []int
+
+func (t SegTree) Update(p int, v int) {
+	n := len(t) / 2
+	p += n
+	t[p] = v
+	for p > 1 {
+		t[p>>1] = max(t[p], t[p^1])
+		p >>= 1
+	}
+}
+
+func (t SegTree) Get(l int, r int) int {
+	n := len(t) / 2
+	l += n
+	r += n
+	var res int
+	for l < r {
+		if l&1 == 1 {
+			res = max(res, t[l])
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			res = max(res, t[r])
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3915/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3915/solution_test.go
@@ -1,0 +1,31 @@
+package p3915
+
+import "testing"
+
+func runSample(t *testing.T, nums []int, k int, expect int64) {
+	res := maxAlternatingSum(nums, k)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{5, 4, 2}
+	k := 2
+	expect := int64(7)
+	runSample(t, nums, k, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{3, 5, 4, 2, 4}
+	k := 1
+	expect := int64(14)
+	runSample(t, nums, k, expect)
+}
+
+func TestSample3(t *testing.T) {
+	nums := []int{5}
+	k := 1
+	expect := int64(5)
+	runSample(t, nums, k, expect)
+}


### PR DESCRIPTION
## Summary
- add LeetCode solutions for 3908, 3909, and 3910–3915 under `set3900`
- include unit tests where applicable (3911, 3913, 3914, 3915)

## Test plan
- [x] `go test` on new packages (p3908, p3909, p3910–p3915)

Made with [Cursor](https://cursor.com)