### PR TITLE
Add Codeforces 2141 (c–f) solutions and fix 2141c tests

### DIFF
--- a/src/codeforces/set2/set21/set214/set2141/c/problem.md
+++ b/src/codeforces/set2/set21/set214/set2141/c/problem.md
@@ -1,0 +1,80 @@
+# Problem
+
+There is a variable `sum`, initially `0`.
+
+There is also a data structure that supports:
+
+- `pushback x` — append an element with value `x`;
+- `pushfront x` — prepend an element with value `x`;
+- `popback` — remove the last element;
+- `popfront` — remove the first element;
+- `min` — add the current minimum element in the structure to `sum`.
+
+Operations `popback`, `popfront`, and `min` must not be used on an empty structure.
+
+Using this structure, you want to produce a sequence of commands so that after all operations, `sum` equals the sum of minima over **all non-empty subarrays** of an array `a` of `n` elements.
+
+More formally: find at most `n * (n + 2)` commands such that for **any** array `a` of length `n`, after executing them,
+
+`sum = sum_{0 <= l <= r < n} min(a[l], ..., a[r])`.
+
+## Input
+
+The first line contains a single integer `n` (`1 <= n <= 500`) — the length of the array.
+
+## Output
+
+Output `k` (`1 <= k <= n * (n + 2)`) lines — each command is one of:
+
+- `pushback a[i]`, where `i` is in `0 .. n-1`;
+- `pushfront a[i]`, where `i` is in `0 .. n-1`;
+- `popback`;
+- `popfront`;
+- `min`.
+
+If there are multiple valid answers, output any.
+
+## Example
+
+### Example 1
+
+**Input**
+
+```text
+1
+```
+
+**Output**
+
+```text
+3
+pushback a[0]
+min
+popfront
+```
+
+### Example 2
+
+**Input**
+
+```text
+2
+```
+
+**Output**
+
+```text
+6
+pushfront a[1]
+min
+pushback a[0]
+min
+popfront
+min
+```
+
+
+### ideas
+1. 也就是要在不超过n*(n+2)个操作里， 得到sum(min(l..r)) (l <= r)
+2. n * (n + 2) = n * n + 2 * n
+3. 

--- a/src/codeforces/set2/set21/set214/set2141/c/solution.go
+++ b/src/codeforces/set2/set21/set214/set2141/c/solution.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var n int
+	fmt.Scan(&n)
+	res := solve(n)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	fmt.Fprintln(writer, len(res))
+	for _, cur := range res {
+		fmt.Fprintln(writer, cur)
+	}
+}
+
+func solve(n int) []string {
+
+	pushBack := func(i int) string {
+		return fmt.Sprintf("pushback a[%d]", i-1)
+	}
+
+	var res []string
+	d := 1
+	for l := 1; l <= n; l++ {
+		if d == 1 {
+			r := l
+			for r <= n {
+				res = append(res, pushBack(r))
+				res = append(res, "min")
+				r++
+			}
+			// r > n
+			d = -1
+		} else {
+			r := n
+			// d = -1
+			// r = n
+			for r > l {
+				res = append(res, "min")
+				res = append(res, "popback")
+				r--
+			}
+			// l = r 但是还没有查询
+			// res = append(res, "min")
+			res = append(res, "min")
+			d = 1
+		}
+
+		if l < n {
+			res = append(res, "popfront")
+		}
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set21/set214/set2141/c/solution.kt
+++ b/src/codeforces/set2/set21/set214/set2141/c/solution.kt
@@ -1,0 +1,77 @@
+import java.io.BufferedInputStream
+import java.lang.StringBuilder
+
+private class FastScanner {
+    private val input = BufferedInputStream(System.`in`)
+    private val buffer = ByteArray(1 shl 16)
+    private var len = 0
+    private var ptr = 0
+
+    private fun readByte(): Int {
+        if (ptr >= len) {
+            len = input.read(buffer)
+            ptr = 0
+            if (len <= 0) return -1
+        }
+        return buffer[ptr++].toInt()
+    }
+
+    fun nextInt(): Int {
+        var c = readByte()
+        while (c <= 32) c = readByte()
+        var sign = 1
+        if (c == '-'.code) {
+            sign = -1
+            c = readByte()
+        }
+        var res = 0
+        while (c > 32) {
+            res = res * 10 + (c - '0'.code)
+            c = readByte()
+        }
+        return res * sign
+    }
+}
+
+private fun solve(n: Int): List<String> {
+    val res = ArrayList<String>()
+    var d = 1
+    for (l in 1..n) {
+        if (d == 1) {
+            var r = l
+            while (r <= n) {
+                res.add("pushback a[${r - 1}]")
+                res.add("min")
+                r++
+            }
+            d = -1
+        } else {
+            var r = n
+            while (r > l) {
+                res.add("min")
+                res.add("popback")
+                r--
+            }
+            res.add("min")
+            d = 1
+        }
+
+        if (l < n) {
+            res.add("popfront")
+        }
+    }
+    return res
+}
+
+fun main() {
+    val fs = FastScanner()
+    val n = fs.nextInt()
+    val ans = solve(n)
+    val out = StringBuilder()
+    out.append(ans.size).append('\n')
+    for (cmd in ans) {
+        out.append(cmd).append('\n')
+    }
+    print(out.toString())
+}
+

--- a/src/codeforces/set2/set21/set214/set2141/c/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2141/c/solution_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, n int) {
+	res := solve(n)
+	if len(res) > n*(n+2) {
+		t.Fatalf("Sample result process %d times, exceeds n * (n+2)", len(res))
+	}
+	marked := make([][]bool, n+1)
+	for i := range n + 1 {
+		marked[i] = make([]bool, n+1)
+	}
+	que := make([]int, 2*n)
+	head, tail := n, n
+	for _, cur := range res {
+		if strings.HasPrefix(cur, "pushback") {
+			w := strings.Index(cur, "a[")
+			v := strings.Index(cur, "]")
+			i, _ := strconv.Atoi(cur[w+2 : v])
+			que[head] = i
+			head++
+		} else if strings.HasSuffix(cur, "pushfront") {
+			w := strings.Index(cur, "a[")
+			v := strings.Index(cur, "]")
+			i, _ := strconv.Atoi(cur[w+2 : v])
+			tail--
+			que[tail] = i
+		} else if cur == "popback" {
+			head--
+		} else if cur == "popfront" {
+			tail++
+		} else {
+			// min
+			if tail == head {
+				t.Fatalf("result is invalid, can't query min on empty")
+			}
+			for i := tail + 1; i < head; i++ {
+				if que[i] != que[i-1]+1 {
+					t.Fatalf("result is invalid, query min on %v, not continuse", que[tail:head])
+				}
+			}
+			marked[que[tail]][que[head-1]] = true
+		}
+		if head < tail {
+			t.Fatalf("result is invalid")
+		}
+	}
+	for l := 0; l < n; l++ {
+		for r := l; r < n; r++ {
+			if !marked[l][r] {
+				t.Fatalf("Sample result is invalid, it not asked range [%d: %d] (0-based)", l, r)
+			}
+		}
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, 1)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 2)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 3)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, 4)
+}
+
+func TestSample5(t *testing.T) {
+	runSample(t, 100)
+}
+

--- a/src/codeforces/set2/set21/set214/set2141/d/problem.md
+++ b/src/codeforces/set2/set21/set214/set2141/d/problem.md
@@ -1,0 +1,78 @@
+# Problem
+
+You are given an integer array `a` with `n` elements. You need to make all elements equal.
+
+You may perform the following operation at most `k` times:
+
+- choose any index `i` (`1 <= i <= n`) and increase `a[i]` by `1`.
+
+If the chosen element `a[i]` is strictly greater than the current minimum element of the array before the increment, you earn one coin.
+
+Find the maximum number of coins you can earn while making all array elements equal.
+
+## Input
+
+The first line contains integer `t` (`1 <= t <= 1000`) — the number of test cases.
+
+For each test case:
+
+- First line: two integers `n` and `k` (`2 <= n <= 3 * 10^5`, `1 <= k <= 10^12`) — array length and maximum operations.
+- Second line: `n` integers `a1, a2, ..., an` (`1 <= ai <= 10^9`) — the array.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `3 * 10^5`.
+
+## Output
+
+For each test case:
+
+- print `-1` if it is impossible to make all elements equal within at most `k` operations;
+- otherwise, print the maximum possible number of coins.
+
+## Example
+
+**Input**
+
+```text
+4
+3 16
+1 10 2
+4 20
+6 2 4 9
+5 9
+7 7 7 7 7
+2 1000000000000
+1000000000 1000000000
+```
+
+**Output**
+
+```text
+-1
+11
+0
+499999999999
+```
+
+## Note
+
+In the first test case, at least `17` operations are needed to make all elements equal (for example, to `[10, 10, 10]`), so the answer is `-1`.
+
+In the second test case, one optimal sequence is:
+
+- increase `a3 = 4` to `10`,
+- increase `a1 = 6` to `10`,
+- increase `a4 = 9` to `10`,
+- increase `a2 = 2` to `10`.
+
+This uses `19` operations and earns `(10 - 4) + (10 - 6) + (10 - 9) = 11` coins, because increments on the current minimum element (`a2` here) do not give coins.
+
+In the third test case, you can keep the array unchanged or make all elements `8`; both give `0` coins.
+
+
+### ideas
+1. 这个题目咋像谜语一样呢？
+2. 假设目前的最小值是w
+3. 操作次数有限制，最多k次
+4. 而且最后需要大家一样，那么就有 n * avg <= sum + k
+5. 如果avg < max(a) => -1, avg >= max(a)
+6.  

--- a/src/codeforces/set2/set21/set214/set2141/d/solution.go
+++ b/src/codeforces/set2/set21/set214/set2141/d/solution.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(k, a)
+}
+
+func solve(k int, a []int) int {
+	n := len(a)
+	slices.Sort(a)
+	var sum int
+	for _, v := range a {
+		sum += v
+	}
+	avg := (sum + k) / n
+	if avg < a[n-1] {
+		return -1
+	}
+	// avg >= a[n-1]
+	var score int
+	for i := 1; i < n; i++ {
+		diff := avg - a[i]
+		if a[i] == a[0] {
+			diff--
+		}
+		score += max(0, diff)
+	}
+	return score
+}

--- a/src/codeforces/set2/set21/set214/set2141/d/solution.kt
+++ b/src/codeforces/set2/set21/set214/set2141/d/solution.kt
@@ -1,0 +1,72 @@
+import java.io.BufferedInputStream
+import java.lang.StringBuilder
+import kotlin.math.max
+
+private class FastScanner {
+    private val input = BufferedInputStream(System.`in`)
+    private val buffer = ByteArray(1 shl 16)
+    private var len = 0
+    private var ptr = 0
+
+    private fun readByte(): Int {
+        if (ptr >= len) {
+            len = input.read(buffer)
+            ptr = 0
+            if (len <= 0) return -1
+        }
+        return buffer[ptr++].toInt()
+    }
+
+    fun nextLong(): Long {
+        var c = readByte()
+        while (c <= 32) c = readByte()
+        var sign = 1L
+        if (c == '-'.code) {
+            sign = -1L
+            c = readByte()
+        }
+        var res = 0L
+        while (c > 32) {
+            res = res * 10 + (c - '0'.code)
+            c = readByte()
+        }
+        return res * sign
+    }
+
+    fun nextInt(): Int = nextLong().toInt()
+}
+
+private fun solve(k: Long, a: LongArray): Long {
+    val n = a.size
+    a.sort()
+
+    var sum = 0L
+    for (v in a) sum += v
+
+    val avg = (sum + k) / n
+    if (avg < a[n - 1]) return -1L
+
+    var score = 0L
+    for (i in 1 until n) {
+        var diff = avg - a[i]
+        if (a[i] == a[0]) {
+            diff--
+        }
+        score += max(0L, diff)
+    }
+    return score
+}
+
+fun main() {
+    val fs = FastScanner()
+    val tc = fs.nextInt()
+    val out = StringBuilder()
+    repeat(tc) {
+        val n = fs.nextInt()
+        val k = fs.nextLong()
+        val a = LongArray(n) { fs.nextLong() }
+        out.append(solve(k, a)).append('\n')
+    }
+    print(out.toString())
+}
+

--- a/src/codeforces/set2/set21/set214/set2141/d/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2141/d/solution_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Fatalf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, `3 16
+1 10 2
+`, -1)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, `4 20
+6 2 4 9
+`, 11)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, `5 9
+7 7 7 7 7
+`, 0)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, `2 1000000000000
+1000000000 1000000000
+`, 499999999999)
+}
+

--- a/src/codeforces/set2/set21/set214/set2141/e/problem.md
+++ b/src/codeforces/set2/set21/set214/set2141/e/problem.md
@@ -1,0 +1,77 @@
+# Problem
+
+You are given a string `s` consisting of characters `0`, `1`, and/or `?`.
+
+Call a binary string perfect if it can be split into two non-empty parts:
+
+- a prefix `a`,
+- a suffix `b`,
+
+such that `a[i] >= b[i]` for every `i` from `1` to `min(|a|, |b|)`.
+
+Your task is to count the number of ways to replace all question marks independently with `0` or `1` so that the resulting string is perfect.
+
+Two ways are different if they differ in at least one position.
+
+Print the answer modulo `998244353`.
+
+## Input
+
+The first line contains a single integer `t` (`1 <= t <= 10^4`) — the number of test cases.
+
+Each test case contains one line with a string `s` (`2 <= |s| <= 2 * 10^5`) consisting of `0`, `1`, and/or `?`.
+
+It is guaranteed that the sum of `|s|` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, print one integer — the number of valid replacements modulo `998244353`.
+
+## Example
+
+**Input**
+
+```text
+5
+0?1
+011
+????
+110?0
+0?1?
+```
+
+**Output**
+
+```text
+1
+0
+15
+2
+3
+```
+
+## Note
+
+In the first test case, string `001` is valid: it can be split into a prefix of length `1` and a suffix of length `2`.
+
+In the fourth test case, two valid resulting strings are:
+
+- `11010`, which can be split into prefix length `2` and suffix length `3`;
+- `11000`, which can be split into prefix length `4` and suffix length `1`.
+
+## ideas
+1. 假设处理到位置i，把s分成了两部分
+2. 这时候看，能够有多少种方案
+3. 不考虑复杂性，就从头开始, 如果 a[0] > b[0]， 那么方案数 = pow(2, ? 的数量)
+4. 如果a[0] = '?', 且 b[0] = '0' = pow(2, ? - 1) 继续
+5. 分类讨论，处理到尾巴
+6. 但是问题在于，这个复杂性是n*n的；
+7. 那么也可以是 pow(2, ?) - (a < b)
+8. a < b, a[0] < b[0], 或者 a[0...i] = b[0...i], 且 a[i+1] < b[i+1]
+9. 那么这个时候，a[0...i] = b[0...i] 对于b来说就是前缀匹配了
+10. 如果是 s[.] = 0/1, 那么就是直接匹配，如果是?, 看情况，（两个？贡献2）
+11. dp[i] 表示到i为止, s[:i/2] = s[i/2:i] (i只能是偶数)时的计数
+12. 如果s[i+1] > s[i/2+1] => dp[i] * (那些还没有确定的部分的贡献)
+13. 都不需要kmp
+14. 上面理解错了。不是按照i分割后计算，而是先分配？，如果这个分配可以保证 a >= b ， 不管在哪里分割，都是算一次
+15. 

--- a/src/codeforces/set2/set21/set214/set2141/e/solution.go
+++ b/src/codeforces/set2/set21/set214/set2141/e/solution.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var s string
+		fmt.Fscan(reader, &s)
+		res := solve(s)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+const mod = 998244353
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func sub(a, b int) int {
+	return add(a, mod-b)
+}
+
+func mul(a, b int) int {
+	return a * b % mod
+}
+
+func solve(s string) int {
+	// n := len(s)
+	res := 1
+	for _, v := range s {
+		if v == '?' {
+			res = mul(res, 2)
+		}
+	}
+	// 只有0111不可以
+	if check(s) {
+		res = sub(res, 1)
+	}
+	return res
+}
+
+func check(s string) bool {
+	if s[0] == '1' {
+		return false
+	}
+	// s[0] == '0' or '?'
+	for i := 1; i < len(s); i++ {
+		if s[i] == '0' {
+			return false
+		}
+	}
+	return true
+}

--- a/src/codeforces/set2/set21/set214/set2141/e/solution.kt
+++ b/src/codeforces/set2/set21/set214/set2141/e/solution.kt
@@ -1,0 +1,89 @@
+import java.io.BufferedInputStream
+import java.lang.StringBuilder
+
+private const val MOD = 998244353
+
+private class FastScanner {
+    private val input = BufferedInputStream(System.`in`)
+    private val buffer = ByteArray(1 shl 16)
+    private var len = 0
+    private var ptr = 0
+
+    private fun readByte(): Int {
+        if (ptr >= len) {
+            len = input.read(buffer)
+            ptr = 0
+            if (len <= 0) return -1
+        }
+        return buffer[ptr++].toInt()
+    }
+
+    fun nextInt(): Int {
+        var c = readByte()
+        while (c <= 32) c = readByte()
+        var sign = 1
+        if (c == '-'.code) {
+            sign = -1
+            c = readByte()
+        }
+        var res = 0
+        while (c > 32) {
+            res = res * 10 + (c - '0'.code)
+            c = readByte()
+        }
+        return res * sign
+    }
+
+    fun nextToken(): String {
+        var c = readByte()
+        while (c <= 32) c = readByte()
+        val sb = StringBuilder()
+        while (c > 32) {
+            sb.append(c.toChar())
+            c = readByte()
+        }
+        return sb.toString()
+    }
+}
+
+private fun add(a: Int, b: Int): Int {
+    var x = a + b
+    if (x >= MOD) x -= MOD
+    return x
+}
+
+private fun sub(a: Int, b: Int): Int = add(a, MOD - b)
+
+private fun mul(a: Int, b: Int): Int = ((a.toLong() * b) % MOD).toInt()
+
+private fun check(s: String): Boolean {
+    if (s[0] == '1') return false
+    for (i in 1 until s.length) {
+        if (s[i] == '0') return false
+    }
+    return true
+}
+
+private fun solve(s: String): Int {
+    var res = 1
+    for (c in s) {
+        if (c == '?') {
+            res = mul(res, 2)
+        }
+    }
+    if (check(s)) {
+        res = sub(res, 1)
+    }
+    return res
+}
+
+fun main() {
+    val fs = FastScanner()
+    val tc = fs.nextInt()
+    val out = StringBuilder()
+    repeat(tc) {
+        val s = fs.nextToken()
+        out.append(solve(s)).append('\n')
+    }
+    print(out.toString())
+}

--- a/src/codeforces/set2/set21/set214/set2141/e/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2141/e/solution_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	res := solve(s)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `0?1`
+	expect := 1
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `011`
+	expect := 0
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `????`
+	expect := 15
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `110?0`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `0?1?`
+	expect := 3
+	runSample(t, s, expect)
+}
+

--- a/src/codeforces/set2/set21/set214/set2141/f/problem.md
+++ b/src/codeforces/set2/set21/set214/set2141/f/problem.md
@@ -1,0 +1,165 @@
+# Problem
+
+You are given an array `a` of `n` integers.
+
+In one operation, you may remove any chosen set of elements, but the chosen set must satisfy one of the following:
+
+- all chosen elements are equal; or
+- all chosen elements are pairwise distinct.
+
+(Choosing exactly one element is always valid.)
+
+For each `x` from `0` to `n - 1`, find the minimum number of operations needed to make the array size exactly `x`.
+
+## Input
+
+The first line contains integer `t` (`1 <= t <= 10^4`) — the number of test cases.
+
+For each test case:
+
+- The first line contains integer `n` (`1 <= n <= 3 * 10^5`) — the array size.
+- The second line contains `n` integers `a1, a2, ..., an` (`1 <= ai <= n`).
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `3 * 10^5`.
+
+## Output
+
+For each test case, print `n` integers `c0, c1, ..., c_{n-1}`, where `c_i` is the minimum number of operations required to reduce the array size to exactly `i`.
+
+## Example
+
+**Input**
+
+```text
+5
+11
+5 5 5 5 2 2 2 8 6 1 7
+6
+3 3 3 3 3 3
+5
+2 1 3 5 4
+8
+1 1 1 2 3 4 5 6
+1
+1
+```
+
+**Output**
+
+```text
+3 3 2 2 2 1 1 1 1 1 1
+1 1 1 1 1 1
+1 1 1 1 1
+2 2 1 1 1 1 1 1
+1
+```
+
+## Note
+
+In the first sample, one possible way to realize the answers:
+
+- `c0 = 3`: remove `a8, a9, a10, a11`, then `a1, a2, a3, a4`, then `a5, a6, a7`.
+- `c1 = 3`: remove `a8, a9, a10, a11`, then `a1, a2, a3, a4`, then `a5, a6`.
+- `c2 = 2`: remove `a7, a8, a9, a10, a11`, then `a1, a2, a3, a4`.
+- `c3 = 2`: remove `a7, a8, a9, a10, a11`, then `a1, a2, a3`.
+- `c4 = 2`: remove `a7, a8, a9, a10, a11`, then `a1, a2`.
+- `c5 = 1`: remove `a1, a7, a8, a9, a10, a11`.
+- `c6 = 1`: remove `a7, a8, a9, a10, a11`.
+- `c7 = 1`: remove `a1, a2, a3, a4`.
+- `c8 = 1`: remove `a1, a2, a3`.
+- `c9 = 1`: remove `a1, a2`.
+- `c10 = 1`: remove `a7`.
+
+## Key insights (based on `solution.go`)
+
+Let the array have value frequencies `f1, f2, ..., fm` (sum of all frequencies is `n`). The operation type does not care about positions—only about how many equal elements and how many distinct values you choose.
+
+### 1. Model the operation via “remove distinct” `k` times
+
+Consider using exactly `k` operations of the form “remove a set of pairwise distinct elements”.
+
+In one such operation, you can remove **at most one** element from any value `v`. Therefore, across `k` distinct-removal operations:
+
+- a value with frequency `f <= k` can be fully removed (you can remove one from it in each of the `k` operations);
+- a value with frequency `f > k` will still have `f - k` elements remaining **if you never delete this value afterward**.
+
+So for a fixed `k`, each value with `f > k` contributes a “leftover payload” `f - k` that we might keep or delete later.
+
+### 2. Delete any whole value via one “remove equal” operation
+
+Now consider operations of the form “remove a set of equal elements”.
+
+If a value currently has `t > 0` remaining elements, you can remove **all** remaining `t` elements in **one** “equal” operation by picking exactly those remaining elements (they are all equal).
+
+Therefore, for each value with `f > k`, we can decide:
+
+- keep it: it contributes `f - k` to the final remaining size;
+- delete it: it costs `1` extra operation, and contributes `0` remaining elements.
+
+### 3. Reduce it to choosing which `f > k` values to keep
+
+Fix `k`. Let `cntGreater = # { values with f > k }`.
+
+If we keep some subset of these values, then:
+
+- remaining size is `s = sum (f - k)` over kept values;
+- number of “equal” deletions is `cntGreater - keptCount`;
+- total operations is `d = k + (cntGreater - keptCount)`.
+
+In the implementation, values with frequencies are sorted into an array `c`. For each `k`, it finds the first index `j` such that `c[j] > k`; all indices `>= j` are exactly the “values with f > k” (including zeros for unused values).
+
+Then it iterates `i` over possible cut points and uses the convention:
+
+- keep frequencies `c[j], c[j+1], ..., c[i-1]`;
+- delete frequencies `c[i], ..., c[n-1]` (each deleted value costs one “equal” operation).
+
+Under this convention:
+
+- `s` (in code) is the cumulative sum `sum_{t=j..i-1} (c[t] - k)` (leftover elements);
+- `d` (in code) is `k + (n - i)` which equals `k + (#deleted values among those > k)`.
+
+Finally, the code updates:
+
+- `res[s] = min(res[s], d)`,
+
+meaning: the minimum number of operations to leave exactly `s` elements.
+
+### 4. Why there is a final prefix-min step
+
+The implementation finishes with:
+
+- `res[x] = min(res[x], res[x-1])` for `x = 1..n-1`.
+
+This enforces the natural monotonicity: if you can achieve a smaller remaining size with `d` operations, then allowing a larger remaining size cannot require more operations, so `res[x]` should be non-increasing as `x` grows.
+
+## How the code maps to these ideas
+
+The Kotlin/Go logic in `src/codeforces/set2/set21/set214/set2141/f/solution.go` does exactly the following:
+
+1. Build the frequency list `c` of length `n` where `c[v-1]` is the count of value `v` in the array, then sort `c`.
+2. Initialize `res[x] = n` for all `x` (worst-case upper bound).
+3. For each `k` from `0` to `n`:
+   - find `j` where `c[j] > k` (all indices before `j` have `c[idx] <= k`);
+   - maintain `s` as cumulative leftover `sum(c[t] - k)` while moving a cut `i` from `j` upward;
+   - compute `d = k + n - i`;
+   - update `res[s] = min(res[s], d)` when `s < n`.
+4. Apply the monotone improvement `res[x] = min(res[x], res[x-1])`.
+
+## Editorial (dual formulation)
+
+Rephrase the problem: for each number of operations, compute the **maximum** number of elements that can be removed. From that, the original answer follows: if you can remove `m` elements in `k` operations, you can also remove any smaller number of elements in no more than `k` operations.
+
+In this version, each operation either removes one occurrence of **every** remaining distinct value, or removes **all** occurrences of the current maximum-frequency value.
+
+Build `C_1, C_2, ..., C_n` where `C_i` is the count of value `i` in `a`. Only the multiset of counts matters, so sort `C`.
+
+Each operation on `C` does one of:
+
+- subtract `1` from every positive entry (floor at `0`); or
+- set the current maximum entry to `0`.
+
+Order does not matter: if you use `x` operations of the first type and `y` of the second, then `y` maxima become `0` and the rest decrease by `x`, regardless of interleaving.
+
+Iterate over candidate pairs `(x, y)`. Naively `O(n^2)` pairs, but only `O(n)` matter: after removing `y` maxima, there is no reason to take `x` larger than the next maximum; across all `y`, the relevant `x` values number at most `(sum of C_i) + n ≤ 2n`.
+
+To evaluate `(x, y)` on sorted `C`: a two-pointer finds the first index where `C_i > x` — the prefix before that becomes `0`, suffix entries become `C_i - x`. Prefix sums help sum the `y` largest values among the modified array.

--- a/src/codeforces/set2/set21/set214/set2141/f/solution.go
+++ b/src/codeforces/set2/set21/set214/set2141/f/solution.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+func solve(a []int) []int {
+	n := len(a)
+	c := make([]int, n)
+	for _, v := range a {
+		c[v-1]++
+	}
+	slices.Sort(c)
+	res := make([]int, n)
+	for i := range n {
+		res[i] = n
+	}
+
+	for j, k := 0, 0; k <= n; k++ {
+		for j < n && c[j] <= k {
+			j++
+		}
+		// 这个s是剩余的元素个数
+		var s int
+		for i := j; i <= n && s < n; i++ {
+			d := k + n - i
+			res[s] = min(res[s], d)
+			if i < n {
+				s += c[i] - k
+			}
+		}
+	}
+
+	for i := 1; i < n; i++ {
+		res[i] = min(res[i], res[i-1])
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set21/set214/set2141/f/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2141/f/solution_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if !slices.Equal(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `11
+5 5 5 5 2 2 2 8 6 1 7
+`
+// 1 2 2 2 5 5 5 5 6 7 8
+	expect := []int{3, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `6
+3 3 3 3 3 3
+`
+	expect := []int{1, 1, 1, 1, 1, 1}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5
+2 1 3 5 4
+`
+	expect := []int{1, 1, 1, 1, 1}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `8
+1 1 1 2 3 4 5 6
+`
+	expect := []int{2, 2, 1, 1, 1, 1, 1, 1}
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `1
+1
+`
+	expect := []int{1}
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- Add `set2141` Div2 problems c–f: `problem.md`, Go/Kotlin (c,d,e) where present, `solution_test.go` for Go.
- Fix `2141c` `solution_test.go`: expected subarray ranges use 0-based `[l,r]` to match `pushback a[i]` indices.

## Test plan
- [x] `go test ./src/codeforces/set2/set21/set214/set2141/c/ .../f/ -count=1`

Made with [Cursor](https://cursor.com)