### PR TITLE
Add Codeforces 2138 C1/C2, 2163C solve2, AGENTS symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/src/codeforces/set2/set21/set213/set2138/c1/problem.md
+++ b/src/codeforces/set2/set21/set213/set2138/c1/problem.md
@@ -1,0 +1,95 @@
+# C1. Maple and Tree Beauty (Easy Version)
+
+Maple is given a rooted tree consisting of `n` vertices numbered from `1` to `n`, where the root has index `1`. Each vertex of the tree is labeled either zero or one. Unfortunately, Maple forgot how the vertices are labeled and only remembers that there are exactly `k` zeros and `n - k` ones.
+
+For each vertex, we define the **name** of the vertex as the binary string formed by concatenating the labels of the vertices from the root to that vertex. More formally, `name_1 = label_1` and `name_u = name_{p_u} + label_u` for all `2 ≤ u ≤ n`, where `p_u` is the parent of vertex `u` and `+` means string concatenation.
+
+The **beauty** of the tree is the length of the **longest common subsequence** (see note below) of the names of **all leaves** (vertices with no children). Determine the **maximum beauty** over all labelings of the tree with exactly `k` zeros and `n - k` ones.
+
+> **\*** A sequence `a` is a subsequence of a sequence `b` if `a` can be obtained from `b` by deleting zero or more elements from arbitrary positions. The longest common subsequence of strings `s_1, s_2, …, s_m` is the longest string that is a subsequence of every `s_i`.
+
+> **†** A leaf is any vertex without children.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 ≤ t ≤ 50`). The description of the test cases follows.
+
+For each test case:
+
+- The first line contains two integers `n` and `k` (`2 ≤ n ≤ 1000`, `0 ≤ k ≤ n`) — the number of vertices and the number of vertices labeled with zero, respectively.
+- The second line contains `n - 1` integers `p_2, p_3, …, p_n` (`1 ≤ p_i ≤ i - 1`) — the parent of vertex `i`.
+
+There is **no** constraint on the sum of `n` over all test cases.
+
+## Output
+
+For each test case, output a single integer: the maximum beauty among all labelings with exactly `k` zeros and `n - k` ones.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```text
+5
+7 3
+1 1 2 2 3 3
+7 2
+1 1 2 3 1 1
+5 0
+1 2 3 4
+5 2
+1 1 1 1
+5 4
+1 1 1 1
+```
+
+**Output**
+
+```text
+3
+2
+5
+1
+2
+```
+
+### Example 2
+
+**Input**
+
+```text
+5
+2 0
+1
+2 1
+1
+3 0
+1 1
+3 1
+1 2
+3 1
+1 1
+```
+
+**Output**
+
+```text
+2
+2
+2
+3
+2
+```
+
+## Note
+
+In the first test case of **Example 1** (`7 3`), the maximum beauty is `3` when the vertices are labeled with `[0, 0, 0, 1, 1, 1, 1]`; the longest common subsequence is `001`.
+
+In the second test case of **Example 1** (`7 2`), the maximum beauty is `2` when the vertices are labeled with `[1, 0, 0, 1, 1, 1, 1]`; the longest common subsequence is `11`.
+
+
+### ideas
+1. 为n个点分配0/1，（k个0，n-k个1），使的叶子节点的name的子序列有最长的相同的字符
+2. 假设这个长度是w <= 最短的路径

--- a/src/codeforces/set2/set21/set213/set2138/c1/solution.go
+++ b/src/codeforces/set2/set21/set213/set2138/c1/solution.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	p := make([]int, n-1)
+	for i := range n - 1 {
+		fmt.Fscan(reader, &p[i])
+	}
+	return solve(n, k, p)
+}
+
+func solve(n int, k int, p []int) int {
+	adj := make([][]int, n)
+	for i := 1; i < n; i++ {
+		adj[p[i-1]-1] = append(adj[p[i-1]-1], i)
+	}
+
+	var cnt []int
+
+	mostDep := n
+
+	var dfs func(u int, d int)
+	dfs = func(u int, d int) {
+		if len(adj[u]) == 0 {
+			mostDep = min(mostDep, d)
+		}
+		if len(cnt) == d {
+			cnt = append(cnt, 0)
+		}
+		cnt[d]++
+		for _, v := range adj[u] {
+			dfs(v, d+1)
+		}
+	}
+
+	dfs(0, 0)
+
+	dp := make([]bool, n+1)
+	dp[0] = true
+
+	var sum int
+	for i := range mostDep + 1 {
+		v := cnt[i]
+		sum += v
+		for w := sum; w >= v; w-- {
+			if dp[w-v] {
+				dp[w] = true
+			}
+		}
+	}
+
+	for x := 1; x <= sum; x++ {
+		if dp[x] {
+			y := sum - x
+			if x <= k && y <= n-k || x <= n-k && y <= k {
+				return mostDep + 1
+			}
+		}
+	}
+
+	return mostDep
+}
+
+const inf = 1 << 30

--- a/src/codeforces/set2/set21/set213/set2138/c1/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2138/c1/solution_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `7 3
+1 1 2 2 3 3
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `7 2
+1 1 2 3 1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5 0
+1 2 3 4
+`
+	expect := 5
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `5 2
+1 1 1 1
+`
+	expect := 1
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `5 4
+1 1 1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_1(t *testing.T) {
+	s := `2 0
+1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_2(t *testing.T) {
+	s := `2 1
+1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_3(t *testing.T) {
+	s := `3 0
+1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_4(t *testing.T) {
+	s := `3 1
+1 2
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestExample2_5(t *testing.T) {
+	s := `3 1
+1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample7(t *testing.T) {
+	s := `12 7
+1 1 1 2 3 4 5 6 7 7 7
+`
+	expect := 4
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set213/set2138/c2/problem.md
+++ b/src/codeforces/set2/set21/set213/set2138/c2/problem.md
@@ -1,0 +1,95 @@
+# C1. Maple and Tree Beauty (Easy Version)
+
+Maple is given a rooted tree consisting of `n` vertices numbered from `1` to `n`, where the root has index `1`. Each vertex of the tree is labeled either zero or one. Unfortunately, Maple forgot how the vertices are labeled and only remembers that there are exactly `k` zeros and `n - k` ones.
+
+For each vertex, we define the **name** of the vertex as the binary string formed by concatenating the labels of the vertices from the root to that vertex. More formally, `name_1 = label_1` and `name_u = name_{p_u} + label_u` for all `2 ≤ u ≤ n`, where `p_u` is the parent of vertex `u` and `+` means string concatenation.
+
+The **beauty** of the tree is the length of the **longest common subsequence** (see note below) of the names of **all leaves** (vertices with no children). Determine the **maximum beauty** over all labelings of the tree with exactly `k` zeros and `n - k` ones.
+
+> **\*** A sequence `a` is a subsequence of a sequence `b` if `a` can be obtained from `b` by deleting zero or more elements from arbitrary positions. The longest common subsequence of strings `s_1, s_2, …, s_m` is the longest string that is a subsequence of every `s_i`.
+
+> **†** A leaf is any vertex without children.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 ≤ t ≤ 50`). The description of the test cases follows.
+
+For each test case:
+
+- The first line contains two integers `n` and `k` (`2 ≤ n ≤ 1000`, `0 ≤ k ≤ n`) — the number of vertices and the number of vertices labeled with zero, respectively.
+- The second line contains `n - 1` integers `p_2, p_3, …, p_n` (`1 ≤ p_i ≤ i - 1`) — the parent of vertex `i`.
+
+There is **no** constraint on the sum of `n` over all test cases.
+
+## Output
+
+For each test case, output a single integer: the maximum beauty among all labelings with exactly `k` zeros and `n - k` ones.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```text
+5
+7 3
+1 1 2 2 3 3
+7 2
+1 1 2 3 1 1
+5 0
+1 2 3 4
+5 2
+1 1 1 1
+5 4
+1 1 1 1
+```
+
+**Output**
+
+```text
+3
+2
+5
+1
+2
+```
+
+### Example 2
+
+**Input**
+
+```text
+5
+2 0
+1
+2 1
+1
+3 0
+1 1
+3 1
+1 2
+3 1
+1 1
+```
+
+**Output**
+
+```text
+2
+2
+2
+3
+2
+```
+
+## Note
+
+In the first test case of **Example 1** (`7 3`), the maximum beauty is `3` when the vertices are labeled with `[0, 0, 0, 1, 1, 1, 1]`; the longest common subsequence is `001`.
+
+In the second test case of **Example 1** (`7 2`), the maximum beauty is `2` when the vertices are labeled with `[1, 0, 0, 1, 1, 1, 1]`; the longest common subsequence is `11`.
+
+
+### ideas
+1. 为n个点分配0/1，（k个0，n-k个1），使的叶子节点的name的子序列有最长的相同的字符
+2. 假设这个长度是w <= 最短的路径

--- a/src/codeforces/set2/set21/set213/set2138/c2/solution.go
+++ b/src/codeforces/set2/set21/set213/set2138/c2/solution.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/big"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	p := make([]int, n-1)
+	for i := range n - 1 {
+		fmt.Fscan(reader, &p[i])
+	}
+	return solve(n, k, p)
+}
+
+func solve(n int, k int, p []int) int {
+	adj := make([][]int, n)
+	for i := 1; i < n; i++ {
+		adj[p[i-1]-1] = append(adj[p[i-1]-1], i)
+	}
+
+	var cnt []int
+
+	mostDep := n
+
+	var dfs func(u int, d int)
+	dfs = func(u int, d int) {
+		if len(adj[u]) == 0 {
+			mostDep = min(mostDep, d)
+		}
+		if len(cnt) == d {
+			cnt = append(cnt, 0)
+		}
+		cnt[d]++
+		for _, v := range adj[u] {
+			dfs(v, d+1)
+		}
+	}
+
+	dfs(0, 0)
+
+	dp := big.NewInt(0)
+	dp.SetBit(dp, 0, 1)
+
+	var sum int
+	for i := range mostDep + 1 {
+		v := cnt[i]
+		sum += v
+		fp := big.NewInt(0)
+		fp = fp.Lsh(dp, uint(v))
+		dp = dp.Or(dp, fp)
+	}
+
+	for x := 1; x <= sum; x++ {
+		if dp.Bit(x) == 1 {
+			y := sum - x
+			if x <= k && y <= n-k || x <= n-k && y <= k {
+				return mostDep + 1
+			}
+		}
+	}
+
+	return mostDep
+}
+
+const inf = 1 << 30
+
+func copyBits(dst *big.Int, src *big.Int) *big.Int {
+	return dst.SetBits(src.Bits())
+}

--- a/src/codeforces/set2/set21/set213/set2138/c2/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2138/c2/solution_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `7 3
+1 1 2 2 3 3
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `7 2
+1 1 2 3 1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5 0
+1 2 3 4
+`
+	expect := 5
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `5 2
+1 1 1 1
+`
+	expect := 1
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `5 4
+1 1 1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_1(t *testing.T) {
+	s := `2 0
+1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_2(t *testing.T) {
+	s := `2 1
+1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_3(t *testing.T) {
+	s := `3 0
+1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample2_4(t *testing.T) {
+	s := `3 1
+1 2
+`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestExample2_5(t *testing.T) {
+	s := `3 1
+1 1
+`
+	expect := 2
+	runSample(t, s, expect)
+}
+
+func TestExample7(t *testing.T) {
+	s := `12 7
+1 1 1 2 3 4 5 6 7 7 7
+`
+	expect := 4
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set216/set2163/c/solution.go
+++ b/src/codeforces/set2/set21/set216/set2163/c/solution.go
@@ -67,11 +67,32 @@ func solve(a [][]int) int {
 		arr = append(arr, []int{lo, hi})
 	}
 
+	return solve2(n, arr)
+}
+
+func solve2(n int, arr [][]int) int {
+	todo := make([]int, 2*n+1)
+	for _, cur := range arr {
+		l, r := cur[0], cur[1]
+		todo[r] = max(todo[r], l)
+	}
+	var maxL int
+	var res int
+	for _, l := range todo {
+		maxL = max(maxL, l)
+		res += maxL
+	}
+	return res
+}
+
+func solve1(n int, arr [][]int) int {
+
 	close := make([][]int, 2*n+1)
 	for i, cur := range arr {
 		hi := cur[1]
 		close[hi] = append(close[hi], i)
 	}
+
 	var active IntHeap
 
 	marked := make([]bool, len(arr))


### PR DESCRIPTION
## Summary
- Add **2138** Maple and Tree Beauty **C1** (easy) and **C2** (hard): `problem.md`, Go solutions, and tests.
- Update **2163C** `solution.go` with an alternate **solve2** path (original logic kept as **solve1**).
- Add **AGENTS.md** as a symlink to shared agent guidance (matches repo convention).

## Test plan
- [x] `go test ./src/codeforces/set2/set21/set213/set2138/c1/ ./src/codeforces/set2/set21/set213/set2138/c2/ -count=1`
- [x] `go test ./src/codeforces/set2/set21/set216/set2163/c/ -count=1`

## Notes
- `input2141f.txt` left untracked (large local input).

Made with [Cursor](https://cursor.com)