### PR TITLE
Add LC 3917–3920, LCR 039, CF 2140D and 2143D2

### DIFF
--- a/src/codeforces/set2/set21/set214/set2140/d/problem.md
+++ b/src/codeforces/set2/set21/set214/set2140/d/problem.md
@@ -1,0 +1,66 @@
+# D. A Cruel Segment's Thesis
+
+You are given `n` segments on a number line. The `i`-th segment is `[l_i, r_i]`. Initially, all segments are **unmarked**.
+
+Repeat the following until no unmarked segment remains:
+
+- In the `k`-th operation, if there are **at least two** unmarked segments, choose any two unmarked segments `[l_i, r_i]` and `[l_j, r_j]`, **mark both**, and add a **new marked** segment `[x_k, y_k]` such that:
+  - `l_i ≤ x_k ≤ r_i`
+  - `l_j ≤ y_k ≤ r_j`
+  - `x_k ≤ y_k`
+- If **exactly one** unmarked segment remains, mark it.
+
+Your task is to find the **maximum possible sum** of the lengths of **all marked segments** at the end. The length of `[l, r]` is `r - l`.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 ≤ t ≤ 10^4`). The description of the test cases follows.
+
+For each test case:
+
+- The first line contains a single integer `n` (`1 ≤ n ≤ 2 · 10^5`) — the number of segments.
+- Each of the next `n` lines contains two integers `l_i` and `r_i` (`1 ≤ l_i ≤ r_i ≤ 10^9`) — the `i`-th segment.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2 · 10^5`.
+
+## Output
+
+For each test case, print a single integer — the maximum possible total length of all marked segments when the process ends.
+
+## Example
+
+**Input**
+
+```text
+4
+2
+1 1000000000
+1 1000000000
+3
+1 10
+2 15
+3 9
+5
+1 11
+2 7
+15 20
+1 3
+11 15
+1
+1000000000 1000000000
+```
+
+**Output**
+
+```text
+2999999997
+42
+59
+0
+```
+
+## Note
+
+In the first test case, take the two given segments and form the new segment `[1, 10^9]`.
+
+In the second test case, take `[1, 10]` and `[2, 15]` and form `[1, 15]`. Then only `[3, 9]` is still unmarked, and it is marked in the next step.

--- a/src/codeforces/set2/set21/set214/set2140/d/solution.go
+++ b/src/codeforces/set2/set21/set214/set2140/d/solution.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	s := make([][]int, n)
+	for i := 0; i < n; i++ {
+		s[i] = make([]int, 2)
+		fmt.Fscan(reader, &s[i][0], &s[i][1])
+	}
+	return solve(s)
+}
+
+func solve(s [][]int) int {
+	// n := len(s)
+	var sum int
+	var arr []int
+	var sumL int
+	for _, cur := range s {
+		l, r := cur[0], cur[1]
+		sum += r - l
+		// 如果将 -l 换成r, 变化 = -(-l) + r = r + l
+		arr = append(arr, r+l)
+		sumL += l
+	}
+
+	slices.Sort(arr)
+	arr = slices.Compact(arr)
+	tr := NewTree(len(arr))
+
+	for _, cur := range s {
+		l, r := cur[0], cur[1]
+		i := sort.SearchInts(arr, l+r)
+		tr.Update(i, l+r)
+	}
+
+	n := len(s)
+	if n&1 == 0 {
+		return sum - sumL + tr.GetBest(n/2)
+	}
+
+	if n == 1 {
+		return sum
+	}
+
+	var best int
+
+	for _, cur := range s {
+		// 如果cur不算入
+		l, r := cur[0], cur[1]
+		i := sort.SearchInts(arr, l+r)
+		tr.Update(i, -(l + r))
+		tmp := -(sumL - l) + tr.GetBest(n/2) + sum
+		best = max(best, tmp)
+		tr.Update(i, l+r)
+	}
+
+	return best
+}
+
+type Tree struct {
+	cnt []int
+	sum []int
+	sz  int
+}
+
+func NewTree(n int) *Tree {
+	t := new(Tree)
+	t.cnt = make([]int, 4*n)
+	t.sum = make([]int, 4*n)
+	t.sz = n
+	return t
+}
+
+func (t *Tree) Update(p int, v int) {
+	var f func(i int, l int, r int)
+	f = func(i int, l int, r int) {
+		if l == r {
+			t.sum[i] += v
+
+			if v < 0 {
+				t.cnt[i]--
+			} else {
+				t.cnt[i]++
+			}
+			return
+		}
+		mid := (l + r) >> 1
+		if p <= mid {
+			f(2*i+1, l, mid)
+		} else {
+			f(2*i+2, mid+1, r)
+		}
+		t.sum[i] = t.sum[2*i+1] + t.sum[2*i+2]
+		t.cnt[i] = t.cnt[2*i+1] + t.cnt[2*i+2]
+	}
+	f(0, 0, t.sz-1)
+}
+
+func (t *Tree) GetBest(k int) int {
+	if k == 0 {
+		return 0
+	}
+	var f func(i int, l int, r int, k int) int
+
+	f = func(i int, l int, r int, k int) int {
+		if l == r {
+			return t.sum[i] / t.cnt[i] * k
+		}
+		mid := (l + r) / 2
+		if t.cnt[2*i+2] >= k {
+			return f(2*i+2, mid+1, r, k)
+		}
+		return t.sum[2*i+2] + f(2*i+1, l, mid, k-t.cnt[2*i+2])
+	}
+
+	return f(0, 0, t.sz-1, k)
+}

--- a/src/codeforces/set2/set21/set214/set2140/d/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2140/d/solution_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, `2
+1 1000000000
+1 1000000000`, 2999999997)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, `3
+1 10
+2 15
+3 9`, 42)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, `5
+1 11
+2 7
+15 20
+1 3
+11 15`, 59)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, `1
+1000000000 1000000000`, 0)
+}
+
+func TestSample5(t *testing.T) {
+	// 13 + 7 = 20
+	runSample(t, `3
+1 4
+1 8
+4 7`, 20)
+}

--- a/src/codeforces/set2/set21/set214/set2143/d2/problem.md
+++ b/src/codeforces/set2/set21/set214/set2143/d2/problem.md
@@ -1,0 +1,55 @@
+# D2. Inversion Graph Coloring (Hard Version)
+
+This is the **hard** version; here `n ≤ 2000` (see also D1 for the easier constraints).
+
+A sequence `b_1, b_2, …, b_k` is **good** if you can color each index `i` **red** or **blue** so that: for every pair `i < j` with `b_i > b_j` (an inversion), indices `i` and `j` receive **different** colors.
+
+You are given a sequence `a_1, a_2, …, a_n`. Compute the number of **good subsequences** of `a` (including the empty subsequence), modulo `10^9 + 7`.
+
+> **\*** A sequence `b` is a subsequence of `a` if `b` can be obtained from `a` by deleting zero or more elements from arbitrary positions.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 ≤ t ≤ 100`). The description of the test cases follows.
+
+For each test case:
+
+- The first line contains an integer `n` (`1 ≤ n ≤ 2000`) — the length of the sequence.
+- The second line contains `n` integers `a_1, a_2, …, a_n` (`1 ≤ a_i ≤ n`).
+
+It is guaranteed that the sum of `n` over all test cases does not exceed **2000**.
+
+## Output
+
+For each test case, output a single integer: the number of good subsequences modulo `10^9 + 7`.
+
+## Example
+
+**Input**
+
+```text
+4
+4
+4 2 3 1
+7
+7 6 1 2 3 3 2
+5
+1 1 1 1 1
+11
+7 2 1 9 7 3 4 1 3 5 3
+```
+
+**Output**
+
+```text
+13
+73
+32
+619
+```
+
+## Note
+
+In the first test case, the subsequences that are **not** good are `[4, 3, 1]`, `[4, 2, 1]`, and `[4, 2, 3, 1]`. There are `16` subsequences in all, so `16 − 3 = 13` are good.
+
+In the third test case, every subsequence is good.

--- a/src/codeforces/set2/set21/set214/set2143/d2/solution.go
+++ b/src/codeforces/set2/set21/set214/set2143/d2/solution.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+const mod = 1_000_000_007
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+type fenwick []int
+
+func (t fenwick) add(p int, v int) {
+	for p < len(t) {
+		t[p] = add(t[p], v)
+		p += p & -p
+	}
+}
+
+func (t fenwick) get(p int) int {
+	var res int
+	for p > 0 {
+		res = add(res, t[p])
+		p -= p & -p
+	}
+	return res
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+func solve(a []int) int {
+	n := len(a)
+	row := make([]fenwick, n+1)
+	col := make([]fenwick, n+1)
+	for i := range n + 1 {
+		row[i] = make(fenwick, n+1)
+		col[i] = make(fenwick, n+1)
+	}
+
+	update := func(x int, y int, v int) {
+		row[x].add(y, v)
+		col[y].add(x, v)
+	}
+
+	update(1, 1, 1)
+	// 定义 f[x][y] 表示表示第一个递增子序列以 x 结尾、第二个递增子序列以 y 结尾时，好子序列的数目
+	// 为避免重复统计，规定 x >= y
+	for _, v := range a {
+		// 把 v 添加到第一个子序列的后面，必须满足 x <= v 且 y <= v
+		// 枚举 y，f[v][y] += sum_{x <= v} f[x][y]
+		for y := 1; y <= v; y++ {
+			tmp := col[y].get(v)
+			update(v, y, tmp)
+		}
+		// 把 v 添加到第二个子序列的后面，必须满足 y <= v < x，这里 v != x 从而避免重复统计
+		// 枚举 x，f[x][v] += sum_{y <= v} f[x][y]
+		for x := v + 1; x <= n; x++ {
+			tmp := row[x].get(v)
+			update(x, v, tmp)
+		}
+	}
+
+	var ans int
+	for _, f := range row {
+		ans = add(ans, f.get(n))
+	}
+	return ans
+}

--- a/src/codeforces/set2/set21/set214/set2143/d2/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2143/d2/solution_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("expect %d, got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `4
+4 2 3 1`
+	runSample(t, s, 13)
+}
+
+func TestSample2(t *testing.T) {
+	s := `7
+7 6 1 2 3 3 2`
+	runSample(t, s, 73)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5
+1 1 1 1 1`
+	runSample(t, s, 32)
+}
+
+func TestSample4(t *testing.T) {
+	s := `11
+7 2 1 9 7 3 4 1 3 5 3`
+	runSample(t, s, 619)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3917/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3917/solution.go
@@ -1,0 +1,12 @@
+package p3917
+
+func countOppositeParity(nums []int) []int {
+	n := len(nums)
+	ans := make([]int, n)
+	cnt := make([]int, 2)
+	for i := n - 1; i >= 0; i-- {
+		ans[i] = cnt[(nums[i]&1)^1]
+		cnt[nums[i]&1]++
+	}
+	return ans
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3918/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3918/solution.go
@@ -1,0 +1,34 @@
+package p3918
+
+func sumOfPrimesInRange(n int) int {
+	var r int
+	for i := n; i > 0; i /= 10 {
+		r = r*10 + i%10
+	}
+	a := min(r, n)
+	b := max(r, n)
+	set := make([]bool, b+1)
+	var primes []int
+	for i := 2; i <= b; i++ {
+		if !set[i] {
+			set[i] = true
+			primes = append(primes, i)
+		}
+		for _, j := range primes {
+			if i*j > b {
+				break
+			}
+			set[i*j] = true
+			if i%j == 0 {
+				break
+			}
+		}
+	}
+	var sum int
+	for _, p := range primes {
+		if p >= a {
+			sum += p
+		}
+	}
+	return sum
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3919/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3919/solution.go
@@ -1,0 +1,35 @@
+package p3919
+
+func minCost(nums []int, queries [][]int) []int {
+	n := len(nums)
+	dp := make([]int, n)
+	for i := n - 2; i >= 0; i-- {
+		dp[i] = dp[i+1]
+		if i == 0 || nums[i+1]-nums[i] < nums[i]-nums[i-1] {
+			dp[i]++
+		} else {
+			dp[i] += nums[i+1] - nums[i]
+		}
+	}
+
+	fp := make([]int, n)
+	for i := 1; i < n; i++ {
+		fp[i] = fp[i-1]
+		if i == n-1 || nums[i]-nums[i-1] <= nums[i+1]-nums[i] {
+			fp[i]++
+		} else {
+			fp[i] += nums[i] - nums[i-1]
+		}
+	}
+
+	ans := make([]int, len(queries))
+	for i, q := range queries {
+		l, r := q[0], q[1]
+		if l < r {
+			ans[i] = dp[l] - dp[r]
+		} else if l > r {
+			ans[i] = fp[l] - fp[r]
+		}
+	}
+	return ans
+}

--- a/src/leetcode/set1000/set3000/set3900/set3910/p3919/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3910/p3919/solution_test.go
@@ -1,0 +1,27 @@
+package p3919
+
+import (
+	"reflect"
+	"testing"
+)
+
+func runSample(t *testing.T, nums []int, queries [][]int, expect []int) {
+	res := minCost(nums, queries)
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("Sample %v, %v, expect %v, but got %v", nums, queries, expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{-5, -2, 3}
+	queries := [][]int{{0, 2}, {2, 0}, {1, 2}}
+	expect := []int{6, 2, 5}
+	runSample(t, nums, queries, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{0, 2, 3, 9}
+	queries := [][]int{{3, 0}, {1, 2}, {2, 0}}
+	expect := []int{4, 1, 3}
+	runSample(t, nums, queries, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3920/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3920/solution.go
@@ -1,0 +1,81 @@
+package p3920
+
+import (
+	"cmp"
+	"slices"
+)
+
+func maxFixedPoints(nums []int) int {
+	n := len(nums)
+	// 对于当前(i, v)来说，要找到左边(j, w), w < v, v - w <= i - j
+	// i - v >= j - w (这个范围内的最大值)
+	// 但是这里没法保证 v < w
+	// 按照v升序处理
+	type pair struct {
+		first  int
+		second int
+	}
+
+	arr := make([]pair, n)
+	for i, v := range nums {
+		arr[i] = pair{v, i}
+	}
+
+	slices.SortFunc(arr, func(a, b pair) int {
+		return cmp.Or(a.first-b.first, a.second-b.second)
+	})
+
+	dp := make(SegTree, 2*n)
+
+	for i := 0; i < n; {
+		j := i
+		var todo []pair
+		for i < n && arr[i].first == arr[j].first {
+			if arr[i].first <= arr[i].second {
+				d := arr[i].second - arr[i].first
+				v := dp.Get(0, d+1) + 1
+				todo = append(todo, pair{i, v})
+			}
+			i++
+		}
+		for _, cur := range todo {
+			i, v := cur.first, cur.second
+			d := arr[i].second - arr[i].first
+			dp.Set(d, v)
+		}
+	}
+
+	return dp.Get(0, n)
+}
+
+type SegTree []int
+
+func (t SegTree) Set(p int, v int) {
+	n := len(t) / 2
+	p += n
+	t[p] = v
+	for p > 1 {
+		t[p>>1] = max(t[p], t[p^1])
+		p >>= 1
+	}
+}
+
+func (t SegTree) Get(l int, r int) int {
+	n := len(t) / 2
+	l += n
+	r += n
+	var res int
+	for l < r {
+		if l&1 == 1 {
+			res = max(res, t[l])
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			res = max(res, t[r])
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3920/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3920/solution_test.go
@@ -1,0 +1,40 @@
+package p3920
+
+import "testing"
+
+func runSample(t *testing.T, nums []int, expect int) {
+	res := maxFixedPoints(nums)
+	if res != expect {
+		t.Errorf("Sample %v, expect %d, but got %d", nums, expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	nums := []int{0, 2, 1}
+	expect := 2
+	runSample(t, nums, expect)
+}
+
+func TestSample2(t *testing.T) {
+	nums := []int{3, 1, 2}
+	expect := 2
+	runSample(t, nums, expect)
+}
+
+func TestSample3(t *testing.T) {
+	nums := []int{1, 0, 1, 2}
+	expect := 3
+	runSample(t, nums, expect)
+}
+
+func TestSample4(t *testing.T) {
+	nums := []int{0, 3, 2}
+	expect := 2
+	runSample(t, nums, expect)
+}
+
+func TestSample5(t *testing.T) {
+	nums := []int{6, 4, 0, 4, 4, 5}
+	expect := 2
+	runSample(t, nums, expect)
+}

--- a/src/leetcodecn/lcr039/solution.go
+++ b/src/leetcodecn/lcr039/solution.go
@@ -1,0 +1,87 @@
+package lcr039
+
+import (
+	"cmp"
+	"slices"
+)
+
+type pair struct {
+	first  int
+	second int
+}
+
+func largestRectangleArea(heights []int) int {
+	heights = append(heights, 0)
+	n := len(heights)
+	stack := make([]int, n)
+	var top int
+	var best int
+	for i, v := range heights {
+		for top > 0 && heights[stack[top-1]] > v {
+			h := heights[stack[top-1]]
+			l := -1
+			if top > 1 {
+				l = stack[top-2]
+			}
+			best = max(best, h*(i-l-1))
+			top--
+		}
+
+		stack[top] = i
+		top++
+	}
+	return best
+}
+
+func largestRectangleArea1(heights []int) int {
+	n := len(heights)
+	arr := make([]pair, n)
+	for i, v := range heights {
+		arr[i] = pair{v, i}
+	}
+
+	slices.SortFunc(arr, func(a, b pair) int {
+		return cmp.Or(b.first-a.first, a.second-b.second)
+	})
+
+	L := make([]int, n)
+	R := make([]int, n)
+	for i := range L {
+		L[i] = i
+		R[i] = i
+	}
+
+	find := func(fa []int, x int) int {
+		y := fa[x]
+		for y != fa[y] {
+			y = fa[y]
+		}
+		for fa[x] != y {
+			x, fa[x] = fa[x], y
+		}
+		return y
+	}
+
+	marked := make([]bool, n)
+
+	var best int
+	for _, p := range arr {
+		h, i := p.first, p.second
+		if i > 0 && marked[i-1] {
+			l := find(L, i-1)
+			L[i] = l
+			R[l] = i
+		}
+		if i+1 < n && marked[i+1] {
+			r := find(R, i+1)
+			R[i] = r
+			L[r] = i
+		}
+		l := find(L, i)
+		r := find(R, i)
+		best = max(best, h*(r-l+1))
+		marked[i] = true
+	}
+
+	return best
+}

--- a/src/leetcodecn/lcr039/solution_test.go
+++ b/src/leetcodecn/lcr039/solution_test.go
@@ -1,0 +1,28 @@
+package lcr039
+
+import "testing"
+
+func runSample(t *testing.T, heights []int, expect int) {
+	res := largestRectangleArea(heights)
+	if res != expect {
+		t.Errorf("Sample %v, expect %d, but got %d", heights, expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	heights := []int{2, 1, 5, 6, 2, 3}
+	expect := 10
+	runSample(t, heights, expect)
+}
+
+func TestSample2(t *testing.T) {
+	heights := []int{2, 4}
+	expect := 4
+	runSample(t, heights, expect)
+}
+
+func TestSample3(t *testing.T) {
+	heights := []int{4, 2, 0, 3, 2, 4, 3, 4}
+	expect := 10
+	runSample(t, heights, expect)
+}


### PR DESCRIPTION
## Summary
- Add **LeetCode** `p3917` / `p3918` (solutions only), `p3919` / `p3920` with `solution_test.go`.
- Add **LeetCode CN** **LCR 039** with tests.
- Add **Codeforces** **2140D** (formatted `problem.md`, Go solution, tests) and **2143 D2** (hard, problem + solution + tests).

## Test plan
- [x] `go test` on `p3919`, `p3920`, `2140/d`, `2143/d2`, `leetcodecn/lcr039`
- [x] `p3917` / `p3918` have no test files (compile-only packages)

Made with [Cursor](https://cursor.com)