### PR TITLE
Add Codeforces 2131G, 2132D/E, and 2175B

### DIFF
--- a/src/codeforces/set2/set21/set213/set2131/g/problem.md
+++ b/src/codeforces/set2/set21/set213/set2131/g/problem.md
@@ -1,0 +1,97 @@
+# G. Wafu!
+
+To help improve her math, Kudryavka is given a set `S` consisting of `n` distinct positive integers.
+
+Initially, her score is `1`. While `S` is not empty, she may perform the following operation:
+
+1. Let `m` be the minimum value in `S`.
+2. Multiply her score by `m`.
+3. Remove `m` from `S`.
+4. For every integer `i` such that `1 <= i < m`, add `i` to `S`.
+   It can be shown that this step adds no duplicates.
+
+After exactly `k` operations, help her determine her score modulo `10^9 + 7`.
+
+## Input
+
+Each test contains multiple test cases.
+The first line contains the number of test cases `t` (`1 <= t <= 10^4`).
+
+For each test case:
+
+- The first line contains two integers `n` and `k` (`1 <= n <= 2 * 10^5`, `1 <= k <= 10^9`).
+- The second line contains `n` integers `s_1, s_2, ..., s_n`
+  (`1 <= s_i <= 10^9`, `s_i != s_j`) — the elements of the initial set `S`.
+
+It is guaranteed that `S` is non-empty before each of the `k` operations.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output one integer — the answer modulo `10^9 + 7`.
+
+## Example
+
+**Input**
+
+```text
+4
+2 3
+1 3
+3 6
+5 1 4
+2 100
+2 100
+5 15
+1 2 3 4 5
+```
+
+**Output**
+
+```text
+3
+24
+118143737
+576
+```
+
+## Note
+
+In the first test case, the process is:
+
+`{1,3} -> {3} -> {1,2} -> {2}`
+
+- Remove `1`, then remove `3` (after adding `1,2`), then remove `1`.
+- So the removed values are `1, 3, 1`, and the score is `1 * 3 * 1 = 3`.
+
+In the second test case, the score is `1 * 4 * 1 * 2 * 1 * 3 = 24`.
+
+## Solution Summary (from `solution.go`)
+
+1. Sort the set and shift each value by `-1`.
+   - The code works with `v = s_i - 1`, because deleting `s_i` creates the canonical block `1..v`.
+
+2. Precompute `dp[j]` for `j = 0..30`.
+   - `dp[j]` is the product contribution of fully consuming the block `1..(j+1)`.
+   - Recurrence in code:
+     - `dp[j] = (j + 1) * product(dp[0..j-1]) (mod M)`, `M = 1e9+7`.
+   - Since `k <= 1e9`, only powers up to `2^30` matter.
+
+3. Key operation count fact.
+   - Fully consuming block `1..v` takes `2^v` operations.
+   - So in the main loop, if `k >= 2^v` (and `v <= 30`), multiply answer by `dp[v]` and do `k -= 2^v`.
+
+4. First unfinished block is handled by divide-and-conquer `f(v, k)`.
+   - `f(v, k)` returns the contribution of the next `k` operations starting from minimum value `v+1`.
+   - Base: `k == 0 => 1`.
+   - Take current minimum once: multiply by `v+1`, then consume the remaining `k-1` using block decomposition by powers of two.
+   - For each level `j` (small to large):
+     - if `k >= 2^j`, take whole block via `dp[j]`;
+     - otherwise recurse into `f(j, k)` and stop.
+
+5. Why this is fast.
+   - Main loop processes sorted original elements once.
+   - Each full block subtraction removes a power-of-two chunk.
+   - Recursive depth is bounded by ~31.
+   - Overall per test case: `O(n log n + 31^2)` (dominated by sorting).

--- a/src/codeforces/set2/set21/set213/set2131/g/solution.go
+++ b/src/codeforces/set2/set21/set213/set2131/g/solution.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &s[i])
+	}
+	return solve(s, k)
+}
+
+const mod = 1_000_000_007
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return a * b % mod
+}
+
+var dp [31]int
+
+func init() {
+	for i := range 31 {
+		dp[i] = i + 1
+		for j := range i {
+			dp[i] = mul(dp[i], dp[j])
+		}
+	}
+}
+
+func solve(s []int, k int) int {
+	slices.Sort(s)
+
+	for i := range s {
+		s[i]--
+	}
+
+	score := 1
+
+	var f func(v int, k int) int
+
+	f = func(v int, k int) int {
+		if k == 0 {
+			return 1
+		}
+		ans := v + 1
+		v = min(v-1, 30)
+		k--
+		for j := range v + 1 {
+			if k >= 1<<j {
+				ans = mul(ans, dp[j])
+				k -= 1 << j
+			} else {
+				ans = mul(ans, f(j, k))
+				break
+			}
+		}
+		return ans
+	}
+
+	for _, v := range s {
+		if v <= 30 && k >= 1<<v {
+			k -= 1 << v
+			score = mul(score, dp[v])
+		} else {
+			// 1 << v > k
+			score = mul(score, f(v, k))
+			break
+		}
+	}
+
+	return score
+}

--- a/src/codeforces/set2/set21/set213/set2131/g/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2131/g/solution_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `2 3
+1 3`
+	expect := 3
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3 6
+5 1 4`
+	expect := 24
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `2 100
+2 100`
+	expect := 118143737
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set213/set2132/d/problem.md
+++ b/src/codeforces/set2/set21/set213/set2132/d/problem.md
@@ -1,0 +1,48 @@
+# D. From 1 to Infinity
+
+Consider the infinite digit string formed by writing all positive integers in order: `123456789101112131415…`
+
+Vadim **truncates** this string after exactly `k` digits (the rest is discarded). Find the **sum of digits** of the resulting length-`k` prefix.
+
+## Input
+
+Each test file has several test cases. The first line contains an integer `t` (`1 ≤ t ≤ 2 · 10^4`) — the number of test cases.
+
+Each test case is one line with a single integer `k` — how many digits remain (`1 ≤ k ≤ 10^15`).
+
+## Output
+
+For each test case, print one integer: the sum of all digits in that prefix of length `k`.
+
+## Example
+
+**Input**
+
+```text
+6
+5
+10
+13
+29
+1000000000
+1000000000000000
+```
+
+**Output**
+
+```text
+15
+46
+48
+100
+4366712386
+4441049382716054
+```
+
+## Note
+
+In the first test case, the prefix is `12345`.
+
+In the second test case, the prefix is `1234567891`.
+
+In the third test case, the prefix is `1234567891011`.

--- a/src/codeforces/set2/set21/set213/set2132/d/solution.go
+++ b/src/codeforces/set2/set21/set213/set2132/d/solution.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var k int
+		fmt.Fscan(reader, &k)
+		res := solve(k)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func solve(k int) int {
+
+	count := func(n int) int {
+		var sum int
+		cur := 1
+		cnt := 1
+		for cur <= n {
+			next := min(10*cur-1, n)
+			sum += (next - cur + 1) * cnt
+			cur = next + 1
+			cnt++
+		}
+		return sum
+	}
+	check := func(n int) bool {
+		// 1...n sum count >= k
+		return count(n) > k
+	}
+
+	n := sort.Search(k+1, check)
+	n--
+	// count(n) <= k
+	// 计算digits sum
+	// 123...n
+
+	var digits []int
+	for i := n; i > 0; i /= 10 {
+		digits = append(digits, i%10)
+	}
+	slices.Reverse(digits)
+	h := len(digits)
+
+	bases := make([]int, h+1)
+	bases[0] = 1
+	for i := 1; i <= h; i++ {
+		bases[i] = bases[i-1] * 10
+	}
+	var res int
+	var hi int
+	for i, v := range digits {
+		// 有多少个0...v-1
+		// 0...hi
+		for x := range v {
+			res += (hi + 1) * x * bases[h-i-1]
+		}
+		// 0...hi-1
+		for x := v; x < 10; x++ {
+			res += hi * x * bases[h-i-1]
+		}
+		hi = hi*10 + v
+		lo := n - hi*bases[h-i-1]
+		// 如果当前位是v，且高位一致的情况下，
+		// 0....lo
+		res += v * (lo + 1)
+	}
+
+	w := count(n)
+	if w < k {
+		s := fmt.Sprintf("%d", n+1)
+		s = s[:k-w]
+		for _, c := range s {
+			res += int(c - '0')
+		}
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set21/set213/set2132/d/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2132/d/solution_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+)
+
+func runSample(t *testing.T, k int, expect int) {
+	res := solve(k)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	// 12345
+	runSample(t, 5, 15)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 10, 46)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 13, 48)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, 29, 100)
+}
+
+func TestSample5(t *testing.T) {
+	runSample(t, 1000000000, 4366712386)
+}
+
+func TestSample6(t *testing.T) {
+	runSample(t, 1000000000000000, 4441049382716054)
+}

--- a/src/codeforces/set2/set21/set213/set2132/e/problem.md
+++ b/src/codeforces/set2/set21/set213/set2132/e/problem.md
@@ -1,0 +1,78 @@
+# E. Arithmetics Competition
+
+In the arithmetic competition, participants need to achieve the **highest possible sum** from the cards they have. On team **"fst_ezik"**, Vadim has `n` cards with values `a_i`, and Kostya has `m` cards with values `b_i`. In each of the `q` rounds they want to win, but the rules differ slightly from the usual setup.
+
+In each round they are given three integers `x_i`, `y_i`, and `z_i`. The team must choose **exactly** `z_i` cards in total from both piles combined, with Vadim contributing **at most** `x_i` cards from his hand and Kostya **at most** `y_i` from his. For every round, find the **maximum achievable sum** of the chosen cards.
+
+## Input
+
+The input contains several test cases. The first line has a single integer `t` (`1 ≤ t ≤ 10^4`) — the number of test cases.
+
+For each test case:
+
+- The first line has three integers `n`, `m`, `q` (`1 ≤ n, m ≤ 2 · 10^5`, `1 ≤ q ≤ 10^5`) — Vadim’s card count, Kostya’s card count, and the number of rounds.
+- The second line has `n` integers `a_i` — Vadim’s card values (`1 ≤ a_i ≤ 10^9`).
+- The third line has `m` integers `b_i` — Kostya’s card values (`1 ≤ b_i ≤ 10^9`).
+- The next `q` lines each have three integers `x_i`, `y_i`, `z_i` (`0 ≤ x_i ≤ n`, `0 ≤ y_i ≤ m`, `0 ≤ z_i ≤ x_i + y_i`) — caps on how many cards Vadim and Kostya may use, and how many cards must be picked in total.
+
+**Guarantee:** the sum of `n` over all test cases ≤ `2 · 10^5`, the sum of `m` over all test cases ≤ `2 · 10^5`, and the sum of `q` over all test cases ≤ `10^5`.
+
+## Output
+
+For each test case, print `q` numbers — the maximum total sum for each round, in order.
+
+## Example
+
+**Input**
+
+```text
+4
+3 4 5
+10 20 30
+1 2 3 4
+0 0 0
+3 4 7
+3 4 4
+1 4 4
+2 2 4
+5 5 2
+500000000 300000000 100000000 900000000 700000000
+800000000 400000000 1000000000 600000000 200000000
+1 4 3
+5 2 6
+4 4 1
+100 100 20 20
+100 100 20 20
+4 4 5
+3 3 6
+2 363 711
+286 121 102
+1 1 1
+3 1 1
+1 2 0
+1 3 2
+0 1 0
+3 3 3
+```
+
+**Output**
+
+```text
+0
+70
+64
+39
+57
+2700000000
+4200000000
+420
+711
+711
+0
+997
+0
+1360
+```
+
+### ideas
+1. sum(a[:x]) + sum(b[:y]) 

--- a/src/codeforces/set2/set21/set213/set2132/e/solution.go
+++ b/src/codeforces/set2/set21/set213/set2132/e/solution.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		ans := drive(reader)
+		for _, v := range ans {
+			fmt.Fprintln(writer, v)
+		}
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n, m, q int
+	fmt.Fscan(reader, &n, &m, &q)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	queries := make([][]int, q)
+	for i := 0; i < q; i++ {
+		var x, y, z int
+		fmt.Fscan(reader, &x, &y, &z)
+		queries[i] = []int{x, y, z}
+	}
+	return solve(a, b, queries)
+}
+
+func solve(a []int, b []int, queries [][]int) []int {
+	s1 := play(a)
+	s2 := play(b)
+
+	n := len(a)
+	m := len(b)
+	todo := make([][]int, n+m+1)
+
+	for i, q := range queries {
+		todo[q[2]] = append(todo[q[2]], i)
+	}
+
+	ans := make([]int, len(queries))
+
+	get := func(arr []int, i int) int {
+		if i < 0 {
+			return 0
+		}
+		return arr[i]
+	}
+
+	for i, j := 0, 0; i < n || j < m; {
+		if j == m || i < n && a[i] >= b[j] {
+			i++
+		} else {
+			j++
+		}
+		k := i + j
+		for _, id := range todo[k] {
+			x, y := queries[id][0], queries[id][1]
+			if x < i {
+				ans[id] = get(s1, x-1) + get(s2, k-x-1)
+			} else if y < j {
+				ans[id] = get(s1, k-y-1) + get(s2, y-1)
+			} else {
+				ans[id] = get(s1, i-1) + get(s2, j-1)
+			}
+		}
+	}
+
+	return ans
+}
+
+func play(arr []int) []int {
+	slices.Sort(arr)
+	slices.Reverse(arr)
+	sum := slices.Clone(arr)
+	for i := 1; i < len(arr); i++ {
+		sum[i] += sum[i-1]
+	}
+	return sum
+}
+
+func solve1(a []int, b []int, queries [][]int) []int {
+	a = play(a)
+	b = play(b)
+
+	get := func(x int, y int) int {
+		var res int
+		if x > 0 {
+			if x <= len(a) {
+				res += a[x-1]
+			} else {
+				res += a[len(a)-1]
+			}
+		}
+		if y > 0 {
+			if y <= len(b) {
+				res += b[y-1]
+			} else {
+				res += b[len(b)-1]
+			}
+		}
+		return res
+	}
+
+	find := func(x int, y int, z int) int {
+		// l + y <= z => l <= z - y
+		l, r := max(0, z-y), min(x, z)
+		for r-l >= 3 {
+			m1 := l + (r-l)/3
+			m2 := r - (r-l)/3
+			s1 := get(m1, z-m1)
+			s2 := get(m2, z-m2)
+			if s1 > s2 {
+				r = m2
+			} else {
+				l = m1
+			}
+		}
+		var res int
+		for i := l; i <= r; i++ {
+			res = max(res, get(i, z-i))
+		}
+		return res
+	}
+
+	ans := make([]int, len(queries))
+	for i, query := range queries {
+		ans[i] = find(query[0], query[1], query[2])
+	}
+	return ans
+
+}

--- a/src/codeforces/set2/set21/set213/set2132/e/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2132/e/solution_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	ans := drive(reader)
+	if !slices.Equal(ans, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, ans)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3 4 5
+10 20 30
+1 2 3 4
+0 0 0
+3 4 7
+3 4 4
+1 4 4
+2 2 4`
+	expect := []int{0, 70, 64, 39, 57}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5 5 2
+500000000 300000000 100000000 900000000 700000000
+800000000 400000000 1000000000 600000000 200000000
+1 4 3
+5 2 6`
+	expect := []int{2700000000, 4200000000}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `4 4 1
+100 100 20 20
+100 100 20 20
+4 4 5`
+	expect := []int{420}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `3 3 6
+2 363 711
+286 121 102
+1 1 1
+3 1 1
+1 2 0
+1 3 2
+0 1 0
+3 3 3`
+	expect := []int{711,
+		711,
+		0,
+		997,
+		0,
+		1360,
+	}
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set217/set2175/b/problem.md
+++ b/src/codeforces/set2/set21/set217/set2175/b/problem.md
@@ -1,0 +1,63 @@
+# B. XOR Array
+
+You are given three integers `n`, `l`, and `r`.
+
+Construct an array `a` of length `n` of **positive** integers with `1 ≤ a_i ≤ 10^9`. For `1 ≤ x ≤ y ≤ n`, let
+
+`f(x, y) = a_x ⊕ a_{x+1} ⊕ … ⊕ a_y`
+
+(bitwise XOR of the subarray `a[x..y]`).
+
+You must satisfy:
+
+- `f(x, y) = 0` **exactly when** `x = l` and `y = r`;
+- for every other pair `(x, y)` with `1 ≤ x ≤ y ≤ n`, **`f(x, y) ≠ 0`**.
+
+> **\*** `⊕` is [bitwise XOR](https://en.wikipedia.org/wiki/Bitwise_operation#XOR).
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 ≤ t ≤ 10^4`). The description of the test cases follows.
+
+Each test case is one line with three integers `n`, `l`, and `r` (`2 ≤ n ≤ 4 · 10^5`, `1 ≤ l < r ≤ n`).
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `5 · 10^5`.
+
+## Output
+
+For each test case, print one line with `n` integers `a_1, a_2, …, a_n`.
+
+A solution always exists. If several arrays work, print any of them.
+
+## Example
+
+**Input**
+
+```text
+4
+3 1 3
+4 1 3
+8 2 4
+4 3 4
+```
+
+**Output**
+
+```text
+9 8 1
+2 7 5 4
+9 1 9 8 10 5 4 9
+85484 130377 6031 6031
+```
+
+## Note
+
+In the first test case, `f(1, 3) = 9 ⊕ 8 ⊕ 1 = 0`, while every **other** non-empty subarray has non-zero XOR:
+
+- `f(1, 2) = 9 ⊕ 8 = 1 ≠ 0`
+- `f(2, 3) = 8 ⊕ 1 = 9 ≠ 0`
+- `f(1, 1) = 9 ≠ 0`
+- `f(2, 2) = 8 ≠ 0`
+- `f(3, 3) = 1 ≠ 0`
+
+In the second test case, `2 ⊕ 7 ⊕ 5 = 0`, while for example `7 ⊕ 5 ⊕ 4 = 6 ≠ 0`.

--- a/src/codeforces/set2/set21/set217/set2175/b/solution.go
+++ b/src/codeforces/set2/set21/set217/set2175/b/solution.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var n, l, r int
+		fmt.Fscan(reader, &n, &l, &r)
+		res := solve(n, l, r)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func solve(n int, l int, r int) []int {
+	res := make([]int, n)
+
+	get := func(i int) int {
+		if i == r {
+			return l - 1
+		}
+		return i
+	}
+
+	for i := range n {
+		res[i] = get(i) ^ get(i+1)
+	}
+	return res
+}

--- a/src/codeforces/set2/set21/set217/set2175/b/solution_test.go
+++ b/src/codeforces/set2/set21/set217/set2175/b/solution_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+)
+
+func runSample(t *testing.T, n int, l int, r int) {
+	res := solve(n, l, r)
+	l--
+	r--
+	for i := range n {
+		var sum int
+		for j := i; j < n; j++ {
+			sum ^= res[j]
+			if i == l && j == r && sum != 0 {
+				t.Fatalf("Sample result %v, is not valid", res)
+			} else if (i != l || j != r) && sum == 0 {
+				t.Fatalf("Sample result %v, is not valid", res)
+			}
+		}
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, 3, 1, 3)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 4, 1, 3)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 8, 2, 4)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, 4, 3, 4)
+}
+
+func TestSample5(t *testing.T) {
+	runSample(t, 100000, 3, 4)
+}
+
+func TestSample6(t *testing.T) {
+	runSample(t, 4, 1, 4)
+}
+
+


### PR DESCRIPTION
## Summary
- Add `2131/g` with formatted statement, Go solution, tests, and a concise solution-summary section.
- Add `2132/d` and `2132/e` with formatted `problem.md`, Go solutions, and tests.
- Add `2175/b` with formatted statement, Go solution, and tests.

## Test plan
- [x] `go test ./src/codeforces/set2/set21/set213/set2131/g/... ./src/codeforces/set2/set21/set213/set2132/... ./src/codeforces/set2/set21/set217/set2175/... -count=1`

Made with [Cursor](https://cursor.com)