### PR TITLE
Add Codeforces 2128D and 2148G solutions

### DIFF
--- a/src/codeforces/set2/set21/set212/set2128/d/problem.md
+++ b/src/codeforces/set2/set21/set212/set2128/d/problem.md
@@ -1,0 +1,252 @@
+# D. Sum of LDS
+
+You are given a permutation `p_1, …, p_n` such that for all `1 ≤ i ≤ n - 2`:
+
+`max(p_i, p_{i+1}) > p_{i+2}`.
+
+For each pair `1 ≤ l ≤ r ≤ n`, consider the subarray `p_l, p_{l+1}, …, p_r` and let **LDS** be the length of its **longest decreasing subsequence**. Compute the sum of LDS over **all** `(l, r)`.
+
+> **\*** A **permutation** of length `n` is an array of `n` distinct integers from `1` to `n` in some order. For example, `[2, 3, 1, 5, 4]` is a permutation; `[1, 2, 2]` is not (duplicate `2`); `[1, 3, 4]` is not a permutation of length `3` (value `4` is out of range).
+
+> **†** For an array `b`, a **decreasing subsequence** of length `k` is indices `i_1 < i_2 < … < i_k` such that `b_{i_1} > b_{i_2} > … > b_{i_k}`.
+
+## Input
+
+Each test contains multiple test cases. The first line contains `t` (`1 ≤ t ≤ 10^4`).
+
+For each test case:
+
+- One line: `n` (`3 ≤ n ≤ 5 · 10^5`).
+- One line: `n` distinct integers `p_1, …, p_n` (`1 ≤ p_i ≤ n`).
+
+It is guaranteed that `max(p_i, p_{i+1}) > p_{i+2}` for all `1 ≤ i ≤ n - 2`.
+
+The sum of `n` over all test cases does not exceed `5 · 10^5`.
+
+## Output
+
+For each test case, print one integer: the sum over all subarrays of the LDS length of that subarray.
+
+## Example
+
+**Input**
+
+```text
+4
+3
+3 2 1
+4
+4 3 1 2
+6
+6 1 5 2 4 3
+3
+2 3 1
+```
+
+**Output**
+
+```text
+10
+17
+40
+8
+```
+
+## Note
+
+For any array `a`, write `LDS(a)` for the length of its longest decreasing subsequence.
+
+In the first test case, every subarray is (strictly) decreasing.
+
+In the second test case:
+
+- `LDS([4]) = LDS([3]) = LDS([1]) = LDS([2]) = 1`
+- `LDS([4, 3]) = LDS([3, 1]) = 2`, `LDS([1, 2]) = 1`
+- `LDS([4, 3, 1]) = 3`, `LDS([3, 1, 2]) = 2`
+- `LDS([4, 3, 1, 2]) = 3`
+
+So the answer is `1 + 1 + 1 + 1 + 2 + 2 + 1 + 3 + 2 + 3 = 17`.
+
+
+### ideas
+1. L[j] 表示 p[i] > p[i+1] .. > p[j]
+2. p[i-1] < p[i], 那么 p[i-2] > p[i] must hold
+
+## Solution explanation
+
+We sum by the right endpoint.
+
+For a fixed right endpoint `r`, define:
+
+`dp[r] = sum LDS(p[l..r])` over all `1 <= l <= r`.
+
+The final answer is:
+
+`sum dp[r]`.
+
+The code does not store the whole `dp` array. It keeps only the current value `dp`, and accumulates it into `res`.
+
+## What the condition gives us
+
+The condition is:
+
+`max(p_i, p_{i+1}) > p_{i+2}`.
+
+Equivalently, there cannot be three consecutive increasing elements:
+
+`p_i < p_{i+1} < p_{i+2}`.
+
+So whenever we see an adjacent increase `p_{i-1} < p_i`, and `i >= 2`, the previous element two positions back must satisfy:
+
+`p_{i-2} > p_i`.
+
+This local restriction is the whole reason the LDS can be updated by looking only at the last adjacent pair.
+
+## Key lemma
+
+For every subarray ending at `i`, compared with the same subarray ending at `i-1`:
+
+- if `p_{i-1} > p_i`, the LDS increases by exactly `1`;
+- if `p_{i-1} < p_i`, the LDS stays the same.
+
+In formula form, for every `l <= i - 1`:
+
+```text
+if p[i-1] > p[i]:
+    LDS(l, i) = LDS(l, i-1) + 1
+else:
+    LDS(l, i) = LDS(l, i-1)
+```
+
+There is also one new subarray `[i, i]`, whose LDS is `1`.
+
+## Why a descent increases every old subarray by 1
+
+Consider `p_{i-1} > p_i`.
+
+For any fixed left endpoint `l`, under the problem condition there is a longest decreasing subsequence of `p[l..i-1]` that ends at position `i-1`. Then we can append `p_i` to it, because:
+
+`p_{i-1} > p_i`.
+
+So:
+
+`LDS(l, i) >= LDS(l, i-1) + 1`.
+
+Adding one new element can increase an LDS by at most `1`, therefore:
+
+`LDS(l, i) = LDS(l, i-1) + 1`.
+
+Intuitively, a descending adjacent pair means the new last element can extend the best decreasing subsequence for every previous left endpoint.
+
+## Why an ascent does not increase old subarrays
+
+Consider `p_{i-1} < p_i`.
+
+The new element `p_i` cannot be appended after `p_{i-1}`. Also, because three consecutive increases are forbidden, if `i >= 2` then:
+
+`p_{i-2} > p_i`.
+
+So `p_i` is not creating a strictly better tail than what was already available before it. Any decreasing subsequence using `p_i` can be matched by a decreasing subsequence of the same length inside `p[l..i-1]`.
+
+Therefore adding `p_i` does not increase the LDS of any old subarray:
+
+`LDS(l, i) = LDS(l, i-1)`.
+
+For the boundary case `i = l`, the new singleton is handled separately.
+
+## Deriving the code transition
+
+Assume we already know:
+
+`dp = sum LDS(p[l..i-1])` for all `l <= i-1`.
+
+When moving to position `i`, there are `i` old subarrays if we use zero-based indexing:
+
+```text
+[0..i-1], [1..i-1], ..., [i-1..i-1]
+```
+
+There is also one new singleton subarray `[i..i]`.
+
+### Case 1: `p[i-1] > p[i]`
+
+Every old subarray gains `1`, and there are `i` old subarrays.
+
+So:
+
+```text
+new_dp = old_dp + i + 1
+```
+
+The `+i` is from increasing all old subarrays by `1`.
+
+The `+1` is from the new singleton `[i..i]`.
+
+This is exactly:
+
+```go
+if p[i-1] > p[i] {
+	dp += i
+}
+dp++
+```
+
+### Case 2: `p[i-1] < p[i]`
+
+No old subarray changes. Only the new singleton contributes `1`.
+
+So:
+
+```text
+new_dp = old_dp + 1
+```
+
+This is also covered by:
+
+```go
+dp++
+```
+
+because the `if p[i-1] > p[i]` block is skipped.
+
+## Meaning of `res`
+
+At the start:
+
+```go
+res := 1
+dp := 1
+```
+
+This corresponds to the only subarray ending at index `0`:
+
+`[0..0]`, whose LDS is `1`.
+
+Then for every later index `i`, the code updates `dp` to become the sum of LDS values over all subarrays ending at `i`, and adds it to `res`:
+
+```go
+res += dp
+```
+
+So after the loop, `res` is the sum over all right endpoints, which is exactly the required answer.
+
+## Example
+
+For `p = [4, 3, 1, 2]`:
+
+- `i = 0`: subarrays ending here: `[4]`, sum is `1`, so `dp = 1`, `res = 1`.
+- `i = 1`: `4 > 3`, old subarrays gain `1`; `dp = 1 + 1 + 1 = 3`. Contributions are `[4,3] = 2`, `[3] = 1`.
+- `i = 2`: `3 > 1`, old subarrays gain `1`; `dp = 3 + 2 + 1 = 6`. Contributions are `[4,3,1] = 3`, `[3,1] = 2`, `[1] = 1`.
+- `i = 3`: `1 < 2`, old subarrays do not change; `dp = 6 + 1 = 7`. Contributions are `[4,3,1,2] = 3`, `[3,1,2] = 2`, `[1,2] = 1`, `[2] = 1`.
+
+Total:
+
+`1 + 3 + 6 + 7 = 17`.
+
+## Complexity
+
+The solution scans the permutation once.
+
+Time complexity: `O(n)` per test case.
+
+Memory complexity: `O(1)` besides the input array.

--- a/src/codeforces/set2/set21/set212/set2128/d/solution.go
+++ b/src/codeforces/set2/set21/set212/set2128/d/solution.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &p[i])
+	}
+	return solve(p)
+}
+
+func solve(p []int) int {
+	n := len(p)
+	res := 1
+	dp := 1
+	// dp表示[?:i]
+	for i := 1; i < n; i++ {
+		if p[i-1] > p[i] {
+			// 这里怎么更新dp?
+			// dp = [?...i-1] 的最大lds的sum
+			// = sum(i-1 - j) where p[j] ... p[i-1]是递减序列
+			// = sum(i - j) = sum(i - (i - 1)) + dp = cur + dp
+			dp += i
+		}
+		dp++
+		res += dp
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set21/set212/set2128/d/solution_test.go
+++ b/src/codeforces/set2/set21/set212/set2128/d/solution_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3
+3 2 1
+	`
+	runSample(t, s, 10)
+}
+
+func TestSample2(t *testing.T) {
+	s := `4
+4 3 1 2
+	`
+	runSample(t, s, 17)
+}
+
+func TestSample3(t *testing.T) {
+	s := `6
+6 1 5 2 4 3
+	`
+	runSample(t, s, 40)
+}
+
+func TestSample4(t *testing.T) {
+	s := `3
+2 3 1
+	`
+	runSample(t, s, 8)
+}

--- a/src/codeforces/set2/set21/set213/set2131/f/problem.md
+++ b/src/codeforces/set2/set21/set213/set2131/f/problem.md
@@ -1,0 +1,25 @@
+# F. Unjust Binary Life
+
+For a fixed target `(x, y)`, every monotone path from `(1, 1)` to `(x, y)` visits every row `1..x` and every column `1..y` at least once. The zero cells on that path form equality constraints
+
+`a_i = b_j`
+
+for all visited cells. Since the path is connected, all visited row and column variables must become one common bit.
+
+Therefore the exact shape of the path does not matter. For prefixes `a[1..x]` and `b[1..y]`, the minimum number of flips is
+
+`min(onesA[x] + onesB[y], zeroesA[x] + zeroesB[y])`.
+
+The task is to sum this over all prefix pairs.
+
+Let
+
+`diffA[x] = onesA[x] - zeroesA[x]`
+
+and similarly for `diffB[y]`. For one fixed `x`, choosing common bit `0` is no worse exactly when
+
+`diffA[x] + diffB[y] <= 0`.
+
+Sort all `b` prefixes by `diffB`. For each `a` prefix, binary-search the last `b` prefix satisfying the inequality. The left part contributes `onesA + onesB`; the right part contributes `zeroesA + zeroesB`. Prefix sums of `onesB` and `zeroesB` make each query `O(log n)`.
+
+Overall complexity is `O(n log n)` per test case.

--- a/src/codeforces/set2/set21/set213/set2131/f/problem.md
+++ b/src/codeforces/set2/set21/set213/set2131/f/problem.md
@@ -1,25 +1,149 @@
 # F. Unjust Binary Life
 
-For a fixed target `(x, y)`, every monotone path from `(1, 1)` to `(x, y)` visits every row `1..x` and every column `1..y` at least once. The zero cells on that path form equality constraints
+## Key observation
 
-`a_i = b_j`
+Cell `(i, j)` is `0` exactly when
 
-for all visited cells. Since the path is connected, all visited row and column variables must become one common bit.
+`a_i xor b_j = 0`, i.e. `a_i = b_j`.
 
-Therefore the exact shape of the path does not matter. For prefixes `a[1..x]` and `b[1..y]`, the minimum number of flips is
+So every zero cell on a valid path says: the row variable `a_i` and the column variable `b_j` must have the same final bit.
 
-`min(onesA[x] + onesB[y], zeroesA[x] + zeroesB[y])`.
+Now fix one target `(x, y)`. Any monotone path from `(1, 1)` to `(x, y)` must:
 
-The task is to sum this over all prefix pairs.
+- visit every row `1..x` at least once, because it starts at row `1` and ends at row `x`;
+- visit every column `1..y` at least once, because it starts at column `1` and ends at column `y`.
 
-Let
+The cells on the path form a connected chain. If every cell on this chain is zero, every touched `a_i` and `b_j` is connected by equality constraints. Therefore all variables in
 
-`diffA[x] = onesA[x] - zeroesA[x]`
+`a_1..a_x` and `b_1..b_y`
 
-and similarly for `diffB[y]`. For one fixed `x`, choosing common bit `0` is no worse exactly when
+must become one common bit.
+
+This condition is also sufficient: if all of these prefix bits are equal, then every cell inside the prefix rectangle is zero, so any monotone path works.
+
+Therefore the shape of the path does not matter. For target `(x, y)`, we only need to decide whether to make all bits in the two prefixes become `0` or become `1`.
+
+## Cost for one target
+
+Let:
+
+- `onesA[x]` be the number of `1`s in `a[1..x]`;
+- `zeroesA[x]` be the number of `0`s in `a[1..x]`;
+- `onesB[y]` and `zeroesB[y]` be defined similarly.
+
+If the common bit is `0`, every original `1` in the two prefixes must be flipped, so the cost is
+
+`onesA[x] + onesB[y]`.
+
+If the common bit is `1`, every original `0` in the two prefixes must be flipped, so the cost is
+
+`zeroesA[x] + zeroesB[y]`.
+
+Thus
+
+`f(x, y) = min(onesA[x] + onesB[y], zeroesA[x] + zeroesB[y])`.
+
+The answer is the sum of this value over all `n^2` prefix pairs.
+
+## Turning the min into a sorted split
+
+For every prefix define
+
+`diff = ones - zeroes`.
+
+For a pair `(x, y)`, choosing final bit `0` is no worse than choosing final bit `1` when
+
+`onesA[x] + onesB[y] <= zeroesA[x] + zeroesB[y]`.
+
+Move terms around:
+
+`(onesA[x] - zeroesA[x]) + (onesB[y] - zeroesB[y]) <= 0`.
+
+That is:
 
 `diffA[x] + diffB[y] <= 0`.
 
-Sort all `b` prefixes by `diffB`. For each `a` prefix, binary-search the last `b` prefix satisfying the inequality. The left part contributes `onesA + onesB`; the right part contributes `zeroesA + zeroesB`. Prefix sums of `onesB` and `zeroesB` make each query `O(log n)`.
+So for a fixed `x`, among all `b` prefixes:
 
-Overall complexity is `O(n log n)` per test case.
+- if `diffB[y] <= -diffA[x]`, contribution is `onesA[x] + onesB[y]`;
+- otherwise, contribution is `zeroesA[x] + zeroesB[y]`.
+
+This is why the code sorts all `b` prefixes by `diff`.
+
+## Matching the code
+
+The `item` struct stores one prefix:
+
+```go
+type item struct {
+	diff  int
+	ones  int
+	zeros int
+}
+```
+
+For prefix ending at zero-based index `i`, its length is `i + 1`, so:
+
+```go
+zeros := i + 1 - ones
+diff := ones - zeros
+```
+
+The code writes the same `diff` as:
+
+```go
+2*ones - i - 1
+```
+
+because `ones - zeros = ones - (i + 1 - ones) = 2*ones - i - 1`.
+
+After sorting all `b` prefixes by `diff`, the code builds prefix sums:
+
+```go
+sumOnes[i+1] = sumOnes[i] + int64(cur.ones)
+sumZeros[i+1] = sumZeros[i] + int64(cur.zeros)
+```
+
+For one `a` prefix `cur`, it finds the first `b` prefix that should use the `zeroes` cost:
+
+```go
+cnt := sort.Search(n, func(i int) bool {
+	return y[i].diff > -cur.diff
+})
+```
+
+So indices `[0, cnt)` satisfy:
+
+`y[i].diff <= -cur.diff`.
+
+These pairs use the common final bit `0`, and each contributes:
+
+`cur.ones + y[i].ones`.
+
+Their total contribution is:
+
+```go
+int64(cnt*cur.ones) + sumOnes[cnt]
+```
+
+The remaining `n - cnt` prefixes use the common final bit `1`, and each contributes:
+
+`cur.zeros + y[i].zeros`.
+
+Their total contribution is:
+
+```go
+int64((n-cnt)*cur.zeros) + sumZeros[n] - sumZeros[cnt]
+```
+
+Adding these two parts for every `a` prefix gives the required sum.
+
+## Complexity
+
+For each test case:
+
+- building prefix records is `O(n)`;
+- sorting `b` prefixes is `O(n log n)`;
+- each `a` prefix does one binary search, so `O(n log n)` total.
+
+Overall complexity is `O(n log n)` per test case, with `O(n)` memory.

--- a/src/codeforces/set2/set21/set213/set2131/f/solution.go
+++ b/src/codeforces/set2/set21/set213/set2131/f/solution.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int64 {
+	var n int
+	var a, b string
+	fmt.Fscan(reader, &n, &a, &b)
+	return solve(a, b)
+}
+
+type item struct {
+	diff  int
+	ones  int
+	zeros int
+}
+
+func solve(a string, b string) int64 {
+	n := len(a)
+	x := make([]item, n)
+	y := make([]item, n)
+
+	var ones int
+	for i := range n {
+		if a[i] == '1' {
+			ones++
+		}
+		zeros := i + 1 - ones
+		x[i] = item{2*ones - i - 1, ones, zeros}
+	}
+
+	ones = 0
+	for i := range n {
+		if b[i] == '1' {
+			ones++
+		}
+		zeros := i + 1 - ones
+		y[i] = item{2*ones - i - 1, ones, zeros}
+	}
+
+	sort.Slice(y, func(i, j int) bool {
+		return y[i].diff < y[j].diff
+	})
+
+	sumOnes := make([]int64, n+1)
+	sumZeros := make([]int64, n+1)
+	for i, cur := range y {
+		sumOnes[i+1] = sumOnes[i] + int64(cur.ones)
+		sumZeros[i+1] = sumZeros[i] + int64(cur.zeros)
+	}
+
+	var ans int64
+	for _, cur := range x {
+		cnt := sort.Search(n, func(i int) bool {
+			return y[i].diff > -cur.diff
+		})
+		ans += int64(cnt*cur.ones) + sumOnes[cnt]
+		ans += int64((n-cnt)*cur.zeros) + sumZeros[n] - sumZeros[cnt]
+	}
+
+	return ans
+}

--- a/src/codeforces/set2/set21/set213/set2131/f/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2131/f/solution_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int64) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `2
+11
+00
+`
+	runSample(t, s, 5)
+}
+
+func TestSample2(t *testing.T) {
+	s := `2
+01
+01
+`
+	runSample(t, s, 4)
+}
+
+func TestSample3(t *testing.T) {
+	s := `4
+1010
+1101
+`
+	runSample(t, s, 24)
+}
+
+func TestSmallAgainstBruteForce(t *testing.T) {
+	for n := 1; n <= 5; n++ {
+		for maskA := 0; maskA < 1<<n; maskA++ {
+			for maskB := 0; maskB < 1<<n; maskB++ {
+				a := makeBinaryString(maskA, n)
+				b := makeBinaryString(maskB, n)
+				res := solve(a, b)
+				expect := bruteForce(a, b)
+				if res != expect {
+					t.Fatalf("n=%d a=%s b=%s expect %d, but got %d", n, a, b, expect, res)
+				}
+			}
+		}
+	}
+}
+
+func makeBinaryString(mask int, n int) string {
+	buf := make([]byte, n)
+	for i := range n {
+		if mask>>i&1 == 1 {
+			buf[i] = '1'
+		} else {
+			buf[i] = '0'
+		}
+	}
+	return string(buf)
+}
+
+func bruteForce(a string, b string) int64 {
+	n := len(a)
+	var ans int64
+	for x := 1; x <= n; x++ {
+		for y := 1; y <= n; y++ {
+			best := 2 * n
+			for maskA := 0; maskA < 1<<n; maskA++ {
+				for maskB := 0; maskB < 1<<n; maskB++ {
+					cost := 0
+					aa := []byte(a)
+					bb := []byte(b)
+					for i := range n {
+						if maskA>>i&1 == 1 {
+							aa[i] ^= 1
+							cost++
+						}
+						if maskB>>i&1 == 1 {
+							bb[i] ^= 1
+							cost++
+						}
+					}
+					if cost < best && reachable(aa, bb, x, y) {
+						best = cost
+					}
+				}
+			}
+			ans += int64(best)
+		}
+	}
+	return ans
+}
+
+func reachable(a []byte, b []byte, x int, y int) bool {
+	dp := make([][]bool, x)
+	for i := range x {
+		dp[i] = make([]bool, y)
+	}
+	for i := range x {
+		for j := range y {
+			if a[i]^b[j] != 0 {
+				continue
+			}
+			if i == 0 && j == 0 {
+				dp[i][j] = true
+			} else if i > 0 && dp[i-1][j] {
+				dp[i][j] = true
+			} else if j > 0 && dp[i][j-1] {
+				dp[i][j] = true
+			}
+		}
+	}
+	return dp[x-1][y-1]
+}

--- a/src/codeforces/set2/set21/set214/set2148/g/problem.md
+++ b/src/codeforces/set2/set21/set214/set2148/g/problem.md
@@ -1,0 +1,131 @@
+Bessie has found an array `a` of length `n` on the floor. There appears to be a handwritten note lying next to the array, seemingly written by Farmer John. The note reads:
+
+Help me, dear Bessie! Let `f(a)` denote the maximum integer `k` in the range `[1, n)` such that:
+
+`gcd(a1, a2, ..., ak) > gcd(a1, a2, ..., a(k+1))`,
+
+or `0` if no such `k` exists.
+
+Bessie decides to help FJ. She defines `g(a)` to represent the maximum value of `f(a)` over all possible reorderings of `a`.
+
+Bessie decides to not only find `g(a)`, but also the value of `g(p)` for all prefixes `p` of `a`.
+
+Output `n` integers, the `i`-th of which is:
+
+`g([a1, a2, ..., ai])`.
+
+## Input
+
+The first line contains an integer `t` (`1 <= t <= 10^4`) — the number of test cases.
+
+The first line of each test case contains an integer `n` (`1 <= n <= 2 * 10^5`).
+
+The following line contains `n` space-separated integers `a1, a2, ..., an` (`1 <= ai <= n`).
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output `n` integers on a new line: the `i`-th of which should be:
+
+`g([a1, a2, ..., ai])`.
+
+## Example
+
+### Input
+
+```text
+3
+8
+2 4 3 6 5 7 8 6
+6
+6 6 6 6 6 6
+9
+8 4 2 6 3 9 5 7 8
+```
+
+### Output
+
+```text
+0 1 2 3 3 3 4 5
+0 0 0 0 0 0
+0 1 2 2 4 4 4 4 5
+```
+
+
+### ideas
+1. g(a) = max(f(a.)), a. 是a的某个排列
+2. 如果gcd(a) = x, 那么让a[i]/= x, 那么 gcd(a) = 1
+3. 然后是否可以得到g(a) = n - 1 ?
+4. 如果所有的a相同， 那么g(a) = 0, 否则g(a) = max(freq) ？
+5. 不是，考虑 a = [4, 2, 3], 那么显然g(a) = 2
+6. 但是如果 a = [4, 2, 3, 5], g(a) = 2 
+7. 如果a中2的倍数，3的倍数，5的倍数，。。。 的最多个个数
+8. 那么加入一个数的时候，只需要把它质因数分解即可
+
+### Correct criterion
+
+For a multiset `S`, consider choosing some integer divisor `d >= 2`.
+
+If we put all numbers divisible by `d` first, then their prefix gcd is still divisible by `d`. If the next number is not divisible by `d`, the gcd strictly drops at exactly
+
+`k = count of numbers divisible by d`.
+
+So any `d` with `0 < cnt[d] < |S|` can achieve `f = cnt[d]`.
+
+Conversely, suppose a permutation has a gcd drop at position `k`:
+
+`gcd(first k numbers) > gcd(first k+1 numbers)`.
+
+Let `D = gcd(first k numbers)`. Since the gcd drops after adding the next element, the next element is not divisible by `D`. All first `k` numbers are divisible by `D`, so at least `k` numbers are divisible by some divisor `D >= 2`, and not all numbers are divisible by `D`.
+
+Therefore:
+
+`g(S) = max cnt[d]` over all `d >= 2` such that `cnt[d] < |S|`.
+
+This is the important correction: it is not enough to count only prime factors. We need all divisors, because if the whole prefix has gcd `6`, the useful drop may come from divisor `4`, `9`, `12`, etc. Example:
+
+`S = [12, 6]`
+
+Both numbers have prime factors `2` and `3`, so prime-frequency counting says no prime can create a drop. But `12` is divisible by `4` and `6` is not, so ordering `[12, 6]` gives a drop at `k = 1`.
+
+### Implementation
+
+Precompute all divisors `d >= 2` for every possible value.
+
+While scanning the prefix, maintain:
+
+- `freq[d]`: how many seen numbers are divisible by `d`;
+- `cnt[c]`: how many divisors currently have frequency `c`;
+- block sums over `cnt`, so we can find the largest non-empty frequency below the current prefix length quickly.
+
+When a new number `x` arrives, for every divisor `d` of `x`:
+
+1. remove the old `freq[d]` from `cnt`;
+2. increment `freq[d]`;
+3. insert the new `freq[d]` into `cnt`.
+
+For prefix length `m = i + 1`, divisors with `freq[d] = m` divide every number in the prefix, so they cannot create a gcd drop. The answer is the maximum stored frequency strictly below `m`, i.e. the maximum in frequency range `[1, m-1]`.
+
+In zero-based code, when processing index `i`, this query range is `[1, i]`.
+
+The first fixed version used a segment tree for this range maximum query, but that is too slow here because every number may have many divisors and every divisor update paid an extra `log n`.
+
+The optimized code uses square-root buckets:
+
+- `cnt[c]` records whether any divisor has current frequency `c`;
+- `sum[block]` records how many active frequencies exist inside that block;
+- update is `O(1)`;
+- query scans block summaries from high to low, then scans inside one non-empty block.
+
+With block size about `sqrt(n)`, each query costs `O(sqrt(n))`, while divisor updates are constant-time. This is faster in practice than a recursive segment tree because the hot loop is the divisor update loop.
+
+### Complexity
+
+Let `tau(x)` be the number of divisors of `x`.
+
+Each number updates all its divisors with `O(1)` work per divisor, then does one bucket query.
+
+Total complexity:
+
+`O(sum tau(a_i) + n sqrt n)`.

--- a/src/codeforces/set2/set21/set214/set2148/g/solution.go
+++ b/src/codeforces/set2/set21/set214/set2148/g/solution.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+const N = 200010
+
+var divisors [N][]int
+
+func init() {
+	for d := 2; d < N; d++ {
+		for x := d; x < N; x += d {
+			divisors[x] = append(divisors[x], d)
+		}
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range a {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+func solve(a []int) []int {
+	n := len(a)
+	res := make([]int, n)
+
+	freq := make([]int, n+1)
+	buckets := NewBuckets(n + 1)
+	incr := func(v int) {
+		if freq[v] > 0 {
+			buckets.Add(freq[v], -1)
+		}
+		freq[v]++
+		buckets.Add(freq[v], 1)
+	}
+
+	for i, num := range a {
+		for _, d := range divisors[num] {
+			incr(d)
+		}
+
+		if i > 0 {
+			res[i] = buckets.Get(i)
+		}
+	}
+
+	return res
+}
+
+const B = 450
+
+type Buckets struct {
+	cnt []int
+	sum []int
+}
+
+func NewBuckets(n int) *Buckets {
+	return &Buckets{
+		cnt: make([]int, n),
+		sum: make([]int, (n+B-1)/B),
+	}
+}
+
+func (b *Buckets) Add(p int, v int) {
+	b.cnt[p] += v
+	b.sum[p/B] += v
+}
+
+func (b *Buckets) Get(r int) int {
+	for block := r / B; block >= 0; block-- {
+		if b.sum[block] == 0 {
+			continue
+		}
+		for i := min(r, (block+1)*B-1); i >= max(1, block*B); i-- {
+			if b.cnt[i] > 0 {
+				return i
+			}
+		}
+	}
+	return 0
+}

--- a/src/codeforces/set2/set21/set214/set2148/g/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2148/g/solution_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if !slices.Equal(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `8
+2 4 3 6 5 7 8 6`
+	expect := []int{0, 1, 2, 3, 3, 3, 4, 5}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `6
+6 6 6 6 6 6`
+	expect := []int{0, 0, 0, 0, 0, 0}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `9
+8 4 2 6 3 9 5 7 8`
+	expect := []int{0, 1, 2, 2, 4, 4, 4, 4, 5}
+	runSample(t, s, expect)
+}
+
+func TestCommonGcdNeedsPrimePowers(t *testing.T) {
+	s := `12
+12 6 1 1 1 1 1 1 1 1 1 1`
+	expect := []int{0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- add complete `solution.go`, `solution_test.go`, and formatted `problem.md` files for Codeforces 2128D and 2148G
- expand the 2131F problem write-up with a step-by-step derivation and complexity explanation for easier review and maintenance
- keep repository structure and per-problem self-contained Go package conventions consistent

## Test plan
- [ ] go test ./src/codeforces/set2/set21/set212/set2128/d/
- [ ] go test ./src/codeforces/set2/set21/set214/set2148/g/

Made with [Cursor](https://cursor.com)