### PR TITLE
Add Codeforces 2147E and 2148F solutions

### DIFF
--- a/src/codeforces/set1/set18/set180/set1805/d/solution.go
+++ b/src/codeforces/set1/set18/set180/set1805/d/solution.go
@@ -4,107 +4,26 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"sort"
 )
 
 func main() {
 	reader := bufio.NewReader(os.Stdin)
-
-	n := readNum(reader)
-	E := make([][]int, n-1)
-	for i := 0; i < n-1; i++ {
-		E[i] = readNNums(reader, 2)
-	}
-	res := solve(n, E)
+	res := drive(reader)
 	s := fmt.Sprintf("%v", res)
 	s = s[1 : len(s)-1]
 	fmt.Println(s)
 }
 
-func readString(reader *bufio.Reader) string {
-	s, _ := reader.ReadString('\n')
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' || s[i] == '\r' {
-			return s[:i]
-		}
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	E := make([][]int, n-1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(reader, &u, &v)
+		E[i] = []int{u, v}
 	}
-	return s
-}
-
-func readNInt64s(reader *bufio.Reader, n int) []int64 {
-	res := make([]int64, n)
-	s, _ := reader.ReadBytes('\n')
-
-	var pos int
-
-	for i := 0; i < n; i++ {
-		pos = readInt64(s, pos, &res[i]) + 1
-	}
-
-	return res
-}
-
-func readInt64(bytes []byte, from int, val *int64) int {
-	i := from
-	var sign int64 = 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	var tmp int64
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int64(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readInt(bytes []byte, from int, val *int) int {
-	i := from
-	sign := 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	tmp := 0
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readNum(reader *bufio.Reader) (a int) {
-	bs, _ := reader.ReadBytes('\n')
-	readInt(bs, 0, &a)
-	return
-}
-
-func readTwoNums(reader *bufio.Reader) (a int, b int) {
-	res := readNNums(reader, 2)
-	a, b = res[0], res[1]
-	return
-}
-
-func readThreeNums(reader *bufio.Reader) (a int, b int, c int) {
-	res := readNNums(reader, 3)
-	a, b, c = res[0], res[1], res[2]
-	return
-}
-
-func readNNums(reader *bufio.Reader, n int) []int {
-	res := make([]int, n)
-	x := 0
-	bs, _ := reader.ReadBytes('\n')
-	for i := 0; i < n; i++ {
-		for x < len(bs) && (bs[x] < '0' || bs[x] > '9') && bs[x] != '-' {
-			x++
-		}
-		x = readInt(bs, x, &res[i])
-	}
-	return res
+	return solve(n, E)
 }
 
 func solve(n int, E [][]int) []int {
@@ -170,27 +89,18 @@ func solve(n int, E [][]int) []int {
 
 	dfs2(-1, 0, 0)
 
-	id := make([]int, n)
-	for i := 0; i < n; i++ {
-		id[i] = i
+	ans := make([]int, n+1)
+	for i := range n {
+		d := dist[i][0].first
+		ans[d+1]++
 	}
-	sort.Slice(id, func(i, j int) bool {
-		return dist[id[i]][0].first < dist[id[j]][0].first
-	})
-	ans := make([]int, n)
-	ans[0] = 1
-	for k, i := 1, 0; k < n; k++ {
-		ans[k] = ans[k-1]
-		for i < n && dist[id[i]][0].first == k {
-			ans[k]++
-			i++
-		}
-		if ans[k] > n {
-			ans[k] = n
-		}
+	ans[1] = 1
+	for i := 2; i <= n; i++ {
+		ans[i] += ans[i-1]
+		ans[i] = min(ans[i], n)
 	}
 
-	return ans
+	return ans[1:]
 }
 
 type Pair struct {

--- a/src/codeforces/set2/set21/set214/set2147/e/problem.md
+++ b/src/codeforces/set2/set21/set214/set2147/e/problem.md
@@ -1,0 +1,204 @@
+You are given an array of `n` non-negative integers.
+
+You want to answer `q` independent scenarios. In the `i`-th scenario, you are allowed to perform the following operation at most `bi` times:
+
+- Choose an element of the array and increase it by `1`.
+
+Your goal is to maximize the number of bits that are equal to `1` in the bitwise OR of all numbers in the array. Find this number for each scenario.
+
+## Input
+
+Each test contains multiple test cases. The first line contains the number of test cases `t` (`1 <= t <= 10^3`). The description of the test cases follows.
+
+The first line of each test case contains two integers `n` and `q` (`1 <= n, q <= 10^5`) — the size of the array and the number of scenarios.
+
+The second line contains `n` integers `a1, a2, ..., an` (`0 <= ai <= 10^9`) — the elements of the array.
+
+The `i`-th of the next `q` lines contains a single integer `bi` (`0 <= bi <= 10^9`) — the maximum number of operations allowed in the `i`-th scenario.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `10^5`, and the sum of `q` over all test cases does not exceed `10^5`.
+
+## Output
+
+For each test case, output `q` lines, the `i`-th of them containing a single integer — the maximum possible number of bits equal to `1` in the bitwise OR in the `i`-th scenario.
+
+## Example
+
+### Input
+
+```text
+3
+1 3
+0
+0
+2
+4
+2 2
+1 3
+0
+3
+2 1
+1000000000 1000000000
+1000000000
+```
+
+### Output
+
+```text
+0
+1
+2
+2
+3
+31
+```
+
+## Note
+
+Visualizer link
+
+**First test case**
+
+- In the first scenario, there are no operations, so the answer is the number of `1`-bits in the bitwise OR of the original array. The array is `0`, which has `0` bits set.
+- In the second scenario, one way to get `1` bit set in the bitwise OR is to increase `a1` by `1` twice, obtaining a bitwise OR of `2 = (10)_2`. This is optimal with at most two operations.
+- In the third scenario, one way to get `2` bits set is to add `1` to `a1` three times, which is optimal. You do not have to use all four allowed operations.
+
+**Second test case**
+
+- In the first scenario, there are no operations, so the answer is the number of `1`-bits in the bitwise OR of the original array, which is `2`.
+- In the second scenario, one way to get `3` bits set is to add `1` to `a2` three times, which is optimal.
+
+### ideas
+1. 最终的or sum = ???11111 类似这样的结构
+2. 
+
+## Solution explanation
+
+Let
+
+`cur = a[0] | a[1] | ... | a[n-1]`.
+
+The bits that are already `1` in `cur` are free. Let their count be:
+
+`bitsCount = popcount(cur)`.
+
+Every operation only increases one array element. The goal for each query budget `b` is to know how many additional missing bits can be made present in the final OR.
+
+The code precomputes a list:
+
+`arr = [(minimum cost, resulting number of set bits)]`.
+
+Then each query only needs a binary search by budget.
+
+## Cost to set one bit
+
+Suppose bit `d` is currently missing from the OR. Then every array element has bit `d = 0`.
+
+For one element `x`, the cheapest way to make its bit `d` become `1` is to increase it to the next number whose bit `d` is set.
+
+Let:
+
+`w = 2^d`.
+
+Only the lower `d` bits matter for this cost. If `x & (w - 1)` is large, then `x` is closer to the next block where bit `d` becomes `1`.
+
+The needed operations are:
+
+`w - (x & (w - 1))`.
+
+So among all elements, we choose the one maximizing:
+
+`x & (w - 1)`.
+
+This is exactly what the code does:
+
+```go
+w := 1 << d1
+for i, v := range a2 {
+	if v&(w-1) > a2[pos]&(w-1) {
+		pos = i
+	}
+}
+ops := w - a2[pos]&(w-1)
+a2[pos] += ops
+```
+
+In Go, `&` has higher precedence than `-`, so the last expression means:
+
+`ops = w - (a2[pos] & (w - 1))`.
+
+## Why process bits from high to low
+
+When we increase a number to set bit `d`, lower bits may change because of carry. For example, turning on bit `2` may clear bits `0` and `1`.
+
+However, after bit `d` is set, later operations for lower bits cannot disturb bit `d`. When a lower missing bit `e < d` is set, the added amount is at most `2^e`, and since bit `e` was `0`, this operation does not carry into higher bits.
+
+Therefore, if we want the final OR to contain a certain missing bit `d` and all useful lower missing bits, the safe order is:
+
+`d, d-1, ..., 0`.
+
+That is why for each candidate highest bit `d`, the code copies the original array and runs:
+
+```go
+for d1 := d; d1 >= 0; d1-- {
+	if or(a2)&(1<<d1) == 0 {
+		...
+	}
+}
+```
+
+Whenever bit `d1` is still absent from the current OR, it pays the minimum cost to make it present.
+
+## What each precomputed pair means
+
+The loop over `d` considers only bits missing from the original OR:
+
+```go
+for d := range 31 {
+	if (sum>>d)&1 == 1 {
+		continue
+	}
+	...
+	bitsCount++
+	arr = append(arr, pair{tot, bitsCount})
+}
+```
+
+For this missing bit `d`, `tot` is the minimum cost needed to make one more originally missing bit available at this level, while also ensuring lower missing bits are repaired after any carry.
+
+The resulting number of set bits is stored as `bitsCount`.
+
+The initial pair:
+
+```go
+arr = append(arr, pair{0, bitsCount})
+```
+
+means that with zero operations, the answer is just the number of set bits in the original OR.
+
+## Answering queries
+
+For a query budget `q`, we need the best precomputed state whose cost is at most `q`.
+
+The costs in `arr` are generated in increasing bit order and are monotonic, so the code binary-searches the first cost that is too large:
+
+```go
+j := sort.Search(len(arr), func(j int) bool {
+	return arr[j].first > q
+})
+ans[i] = arr[j-1].second
+```
+
+So `arr[j-1]` is the best reachable state under this budget.
+
+## Complexity
+
+There are only 31 relevant bits because `a_i, b_i <= 10^9`.
+
+For each missing bit `d`, the implementation may scan the array for each lower bit, so preprocessing costs:
+
+`O(31 * 31 * n)`.
+
+Each query is answered by binary search over at most 32 precomputed states:
+
+`O(log 31)`, effectively constant.

--- a/src/codeforces/set2/set21/set214/set2147/e/solution.go
+++ b/src/codeforces/set2/set21/set214/set2147/e/solution.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n, q int
+	fmt.Fscan(reader, &n, &q)
+	a := make([]int, n)
+	for i := range a {
+		fmt.Fscan(reader, &a[i])
+	}
+	queries := make([]int, q)
+	for i := range queries {
+		fmt.Fscan(reader, &queries[i])
+	}
+	return solve(a, queries)
+}
+
+type pair struct {
+	first  int
+	second int
+}
+
+func solve(a []int, queries []int) []int {
+	n := len(a)
+	a2 := make([]int, n)
+
+	sum := or(a)
+	bitsCount := bits.OnesCount(uint(sum))
+
+	var arr []pair
+	arr = append(arr, pair{0, bitsCount})
+
+	for d := range 31 {
+		if (sum>>d)&1 == 1 {
+			continue
+		}
+		copy(a2, a)
+		var tot int
+		for d1 := d; d1 >= 0; d1-- {
+			if or(a2)&(1<<d1) == 0 {
+				var pos int
+				w := 1 << d1
+				for i, v := range a2 {
+					if v&(w-1) > a2[pos]&(w-1) {
+						pos = i
+					}
+				}
+				ops := w - a2[pos]&(w-1)
+				// 这里和变成0是一致的
+				a2[pos] += ops
+				tot += ops
+			}
+		}
+		bitsCount++
+		arr = append(arr, pair{tot, bitsCount})
+	}
+
+	ans := make([]int, len(queries))
+
+	for i, q := range queries {
+		j := sort.Search(len(arr), func(j int) bool {
+			return arr[j].first > q
+		})
+		ans[i] = arr[j-1].second
+	}
+	return ans
+}
+
+func or(a []int) int {
+	var res int
+	for _, v := range a {
+		res |= v
+	}
+	return res
+}

--- a/src/codeforces/set2/set21/set214/set2147/e/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2147/e/solution_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	ans := drive(reader)
+	if !slices.Equal(expect, ans) {
+		t.Errorf("Sample expect %v, but got %v", expect, ans)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `1 3
+0
+0
+2
+4`
+	expect := []int{0, 1, 2}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `2 2
+1 3
+0
+3`
+	expect := []int{2, 3}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `2 1
+1000000000 1000000000
+1000000000`
+	expect := []int{31}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `1 1
+2
+0`
+	expect := []int{1}
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set214/set2148/f/problem.md
+++ b/src/codeforces/set2/set21/set214/set2148/f/problem.md
@@ -1,0 +1,183 @@
+Farmer John has `n` arrays `a1, a2, ..., an` that may have different lengths. He will stack the arrays on top of each other, resulting in a grid with `n` rows. The arrays are left-aligned and can be stacked in any order he desires.
+
+Then, gravity takes place. Any cell that is not on the bottom row and does not have an element beneath it will fall down one row. This process repeats until no cell satisfies that condition.
+
+Over all possible ways FJ can stack the arrays, output the lexicographically minimum bottom row after gravity finishes.
+
+## Input
+
+The first line contains `t` (`1 <= t <= 1000`) — the number of test cases.
+
+The first line of each test case contains `n` (`1 <= n <= 2 * 10^5`).
+
+For the following `n` lines, the first integer `ki` (`1 <= ki <= 2 * 10^5`) denotes the length of `ai`.
+
+Then `ki` space-separated integers `ai1, ai2, ..., aiki` follow (`1 <= aij <= 2 * 10^5`).
+
+It is guaranteed that the sum of `n` and the sum of all `ki` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output the lexicographically minimum bottom row on a new line.
+
+## Example
+
+### Input
+
+```text
+4
+1
+3 5 2 7
+2
+2 2 9
+3 3 1 4
+3
+1 5
+2 5 1
+2 5 2
+3
+3 4 4 9
+7 7 6 5 4 3 2 1
+4 2 4 5 1
+```
+
+### Output
+
+```text
+5 2 7
+2 9 4
+5 1
+2 4 5 1 3 2 1
+```
+
+
+### ideas
+1. 如果a[i]是第0列最小的，那么就把它放在最小面，如果有多个最小的，那么就需要在它们中间挑选
+2. 挑选的逻辑，也是一直找下去。但是假设某个a[i]比较短，这个时候怎么处理？
+3. 这时候，那些长度 > 它的，都可以往下掉。所以，要把它们也全部算进来，继续处理
+4. 
+
+## Solution explanation
+
+Think about the final bottom row column by column.
+
+After gravity finishes, for a fixed column `d`, only arrays with length `> d` have an element in that column. Among those arrays, the bottom cell of column `d` comes from the lowest stacked array that still has an element in column `d`.
+
+So choosing a stacking order is equivalent to choosing a priority order of arrays from bottom to top:
+
+- for column `d`, scan the priority order from bottom to top;
+- the first array whose length is greater than `d` supplies the bottom-row value at column `d`.
+
+Thus we need to choose this priority order so that the produced sequence is lexicographically minimum.
+
+## Greedy choice
+
+Suppose we are currently deciding answer position `d`.
+
+All arrays with length `<= d` are already irrelevant, because they do not have a value at this column. Among all remaining arrays, the first answer value should clearly be the minimum possible `a[i][d]`.
+
+If only one array has this minimum value, then it must be placed below all other currently active arrays, because using any larger value would make the answer lexicographically worse immediately.
+
+If several arrays tie on `a[i][d]`, then this column cannot distinguish them. We compare their next values:
+
+`a[i][d+1]`, then `a[i][d+2]`, and so on.
+
+This is exactly a lexicographic comparison of the suffixes starting at column `d`, except for one important detail: arrays can have different lengths.
+
+## What happens when one tied array ends
+
+Assume several candidate arrays are equal from column `d` up to column `e-1`, and one of them ends at `e`.
+
+If we put that shorter array at the bottom among these tied candidates, then it contributes the equal prefix `d..e-1`. Starting at column `e`, it has no cell, so gravity exposes the next lowest active array with length `> e`.
+
+This is never worse than choosing a longer tied array first, because the already written prefix is identical, and ending earlier gives us the chance to choose the best continuation from all longer active arrays.
+
+That is why in the code, if during comparison `len(a[i]) == d`, `find` immediately returns this row and this stopping position:
+
+```go
+if len(a[i]) == d {
+	return []int{i, d}
+}
+```
+
+The caller then copies the selected row only up to that ending position, removes all arrays that are no longer active, and continues.
+
+## Matching the code
+
+First, rows are sorted by length:
+
+```go
+slices.SortFunc(rows, func(i int, j int) int {
+	return cmp.Or(len(a[i])-len(a[j]), i-j)
+})
+```
+
+This lets `pos` skip all rows that are too short for the current column:
+
+```go
+for pos < n && len(a[rows[pos]]) <= d {
+	pos++
+}
+```
+
+Now `rows[pos:]` contains exactly the arrays that still have a value at column `d`.
+
+The helper:
+
+```go
+find(rows[pos:], d)
+```
+
+chooses which row should contribute the next segment of the answer.
+
+Inside `find`:
+
+1. Among all candidate rows, find the minimum value in the current column `d`.
+2. Keep only rows with that minimum value.
+3. Move to column `d + 1` and repeat.
+4. Stop when either only one row remains, or some tied row ends.
+
+If one row remains, it is lexicographically best among the active candidates, so it can safely provide values until it ends:
+
+```go
+return []int{rows[0], len(a[rows[0]])}
+```
+
+The main loop receives `(r, d1)` and copies:
+
+```go
+for i := d; i < d1; i++ {
+	ans[i] = a[r][i]
+}
+```
+
+Then it sets:
+
+```go
+d = d1
+```
+
+and repeats the process for the next still-empty column.
+
+## Why this is correct
+
+At each current position `d`, lexicographic order says the smallest possible value at `d` is the only thing that matters first. Therefore all arrays with non-minimum `a[i][d]` can be ignored for the current bottom choice.
+
+If there is a tie, the same argument applies to the next column among the tied rows. This continues until:
+
+- a unique best row is found; or
+- a tied row ends.
+
+In the first case, the unique row has the lexicographically smallest suffix, so choosing it is optimal.
+
+In the second case, all tied rows produce the same segment up to the shorter row's end. Choosing the shorter row first cannot make the written segment worse, and after it ends, all longer rows are still available for the remaining columns. So it is optimal to stop there and re-run the same greedy choice on the remaining active rows.
+
+Since every step fixes the lexicographically smallest possible next segment, the whole answer is lexicographically minimum.
+
+## Complexity
+
+Each call to `find` advances column comparisons while filtering candidate rows by the current minimum value. The total amount of row data processed over the test case is bounded by the total input size up to sorting/filtering overhead.
+
+The implementation also sorts rows by length, so the complexity is:
+
+`O(total length + n log n)` per test case.

--- a/src/codeforces/set2/set21/set214/set2148/f/solution.go
+++ b/src/codeforces/set2/set21/set214/set2148/f/solution.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"cmp"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		ans := drive(reader)
+		s := fmt.Sprintf("%v", ans)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func drive(reader *bufio.Reader) []int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([][]int, n)
+	for i := range n {
+		var k int
+		fmt.Fscan(reader, &k)
+		a[i] = make([]int, k)
+		for j := range k {
+			fmt.Fscan(reader, &a[i][j])
+		}
+	}
+	return solve(a)
+}
+
+type pair struct {
+	first  int
+	second int
+}
+
+func solve(a [][]int) []int {
+	n := len(a)
+	var m int
+	rows := make([]int, n)
+	for i, v := range a {
+		m = max(m, len(v))
+		rows[i] = i
+	}
+
+	find := func(rows []int, d int) []int {
+		for len(rows) > 1 {
+			nextVal := 1 << 60
+			var newRows []int
+			for _, i := range rows {
+				if len(a[i]) == d {
+					return []int{i, d}
+				}
+				nextVal = min(nextVal, a[i][d])
+			}
+			for _, i := range rows {
+				if a[i][d] == nextVal {
+					newRows = append(newRows, i)
+				}
+			}
+			rows = newRows
+			d++
+		}
+		return []int{rows[0], len(a[rows[0]])}
+	}
+
+	slices.SortFunc(rows, func(i int, j int) int {
+		return cmp.Or(len(a[i])-len(a[j]), i-j)
+	})
+
+	ans := make([]int, m)
+
+	var pos int
+	for d := 0; d < m; {
+		for pos < n && len(a[rows[pos]]) <= d {
+			pos++
+		}
+		// 找到这一列的最小值所在的行，可能有多少个
+		tmp := find(rows[pos:], d)
+		r, d1 := tmp[0], tmp[1]
+
+		for i := d; i < d1; i++ {
+			ans[i] = a[r][i]
+		}
+
+		d = d1
+	}
+
+	return ans
+}

--- a/src/codeforces/set2/set21/set214/set2148/f/solution_test.go
+++ b/src/codeforces/set2/set21/set214/set2148/f/solution_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if !slices.Equal(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `1
+3 5 2 7
+`
+	expect := []int{5, 2, 7}
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `2
+2 2 9
+3 3 1 4
+`
+	expect := []int{2, 9, 4}
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `3
+1 5
+2 5 1
+2 5 2
+`
+	expect := []int{5, 1}
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `3
+3 4 4 9
+7 7 6 5 4 3 2 1
+4 2 4 5 1
+`
+	expect := []int{2, 4, 5, 1, 3, 2, 1}
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- add complete solutions and tests for Codeforces 2147E and 2148F
- add local `problem.md` statements for both problems to keep each package self-contained
- simplify and update the Codeforces 1805D solution implementation

## Test plan
- [x] `go test ./src/codeforces/set2/set21/set214/set2147/e/`
- [x] `go test ./src/codeforces/set2/set21/set214/set2148/f/`
- [ ] `go test ./src/codeforces/set1/set18/set180/set1805/d/`

Made with [Cursor](https://cursor.com)