### PR TITLE
Add Codeforces 2089A, 2092E, 2094F, and 2137 F/G

### DIFF
--- a/src/codeforces/set1/set13/set130/set1303/e/solution.go
+++ b/src/codeforces/set1/set13/set130/set1303/e/solution.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 )
@@ -10,80 +9,24 @@ import (
 func main() {
 	reader := bufio.NewReader(os.Stdin)
 
-	tc := readNum(reader)
-
-	var buf bytes.Buffer
-
-	for tc > 0 {
-		tc--
-		s := readString(reader)
-		a := readString(reader)
-		res := solve(s, a)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
 		if res {
-			buf.WriteString("YES\n")
+			fmt.Fprintln(writer, "YES")
 		} else {
-			buf.WriteString("NO\n")
+			fmt.Fprintln(writer, "NO")
 		}
 	}
-
-	fmt.Print(buf.String())
 }
 
-func readString(r *bufio.Reader) string {
-	s, _ := r.ReadBytes('\n')
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' || s[i] == '\r' {
-			return string(s[:i])
-		}
-	}
-	return string(s)
-}
-
-func readInt(bytes []byte, from int, val *int) int {
-	i := from
-	sign := 1
-	if bytes[i] == '-' {
-		sign = -1
-		i++
-	}
-	tmp := 0
-	for i < len(bytes) && bytes[i] >= '0' && bytes[i] <= '9' {
-		tmp = tmp*10 + int(bytes[i]-'0')
-		i++
-	}
-	*val = tmp * sign
-	return i
-}
-
-func readNum(reader *bufio.Reader) (a int) {
-	bs, _ := reader.ReadBytes('\n')
-	readInt(bs, 0, &a)
-	return
-}
-
-func readTwoNums(reader *bufio.Reader) (a int, b int) {
-	res := readNNums(reader, 2)
-	a, b = res[0], res[1]
-	return
-}
-
-func readThreeNums(reader *bufio.Reader) (a int, b int, c int) {
-	res := readNNums(reader, 3)
-	a, b, c = res[0], res[1], res[2]
-	return
-}
-
-func readNNums(reader *bufio.Reader, n int) []int {
-	res := make([]int, n)
-	x := 0
-	bs, _ := reader.ReadBytes('\n')
-	for i := 0; i < n; i++ {
-		for x < len(bs) && (bs[x] < '0' || bs[x] > '9') && bs[x] != '-' {
-			x++
-		}
-		x = readInt(bs, x, &res[i])
-	}
-	return res
+func drive(reader *bufio.Reader) bool {
+	var s, t string
+	fmt.Fscan(reader, &s, &t)
+	return solve(s, t)
 }
 
 func solve(s string, t string) bool {

--- a/src/codeforces/set2/set20/set208/set2089/a/problem.md
+++ b/src/codeforces/set2/set20/set208/set2089/a/problem.md
@@ -1,0 +1,181 @@
+# A. Simple Permutation
+
+Source: <https://codeforces.com/problemset/problem/2089/A>
+
+Given an integer `n`, construct a permutation:
+
+```text
+p_1, p_2, ..., p_n
+```
+
+of length `n`.
+
+For each `1 <= i <= n`, define:
+
+```text
+c_i = ceil((p_1 + p_2 + ... + p_i) / i)
+```
+
+Among:
+
+```text
+c_1, c_2, ..., c_n
+```
+
+there must be at least:
+
+```text
+floor(n / 3) - 1
+```
+
+prime numbers.
+
+It is guaranteed that such a permutation always exists.
+
+## Input
+
+The first line contains an integer `t`:
+
+```text
+1 <= t <= 10
+```
+
+Each test case contains one integer:
+
+```text
+n
+```
+
+Constraints:
+
+```text
+2 <= n <= 100000
+```
+
+## Output
+
+For each test case, output a permutation:
+
+```text
+p_1 p_2 ... p_n
+```
+
+of length `n` satisfying the condition.
+
+If there are multiple valid answers, output any of them.
+
+## Example
+
+### Input
+
+```text
+3
+2
+3
+5
+```
+
+### Output
+
+```text
+2 1
+2 1 3
+2 1 3 4 5
+```
+
+## Note
+
+For `n = 2`:
+
+```text
+c_1 = ceil(2 / 1) = 2
+c_2 = ceil((2 + 1) / 2) = 2
+```
+
+Both values are prime.
+
+For `n = 5`, the sample permutation gives:
+
+```text
+c_1 = 2
+c_2 = 2
+c_3 = 2
+c_4 = 3
+c_5 = 3
+```
+
+All of them are prime.
+
+## Solution
+
+We need many prefixes whose ceiling average is prime. A direct way is to choose one prime number `q`, then make a long prefix where the average always stays close enough to `q` so that:
+
+```text
+ceil(prefix_sum / prefix_len) = q
+```
+
+The code picks `q` as the first prime in this range:
+
+```text
+floor(n / 3) <= q <= ceil(2n / 3)
+```
+
+Then it places numbers around `q` in this order:
+
+```text
+q, q - 1, q + 1, q - 2, q + 2, ...
+```
+
+while all numbers are still inside `[1, n]`. After that, it appends every unused number in increasing order.
+
+For the centered part, after taking symmetric pairs around `q`:
+
+```text
+(q - d) + (q + d) = 2q
+```
+
+So the prefix average keeps returning to `q`. For odd prefix lengths, the prefix is:
+
+```text
+q, q - 1, q + 1, ..., q - d, q + d
+```
+
+Its sum is exactly:
+
+```text
+(2d + 1) * q
+```
+
+and therefore the average is exactly `q`.
+
+For even prefix lengths, the prefix has one extra smaller value `q - d` before its matching `q + d` appears. The sum is:
+
+```text
+2d * q - d
+```
+
+Its average is:
+
+```text
+q - 1/2
+```
+
+so the ceiling is still `q`.
+
+Therefore every prefix inside this centered block contributes a prime `c_i = q`.
+
+Because `q` is chosen between about `n / 3` and `2n / 3`, there are enough valid numbers on both sides of `q` to create at least:
+
+```text
+floor(n / 3) - 1
+```
+
+such prefixes. The rest of the permutation can be filled with any unused numbers because the requirement has already been satisfied.
+
+Time complexity:
+
+```text
+O(n + sqrt(n))
+```
+
+The `sqrt(n)` factor comes from checking primality while searching for `q`, and the permutation construction is linear.

--- a/src/codeforces/set2/set20/set208/set2089/a/solution.go
+++ b/src/codeforces/set2/set20/set208/set2089/a/solution.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var n int
+		fmt.Fscan(reader, &n)
+		res := solve(n)
+		s := fmt.Sprintf("%v", res)
+		fmt.Fprintln(writer, s[1:len(s)-1])
+	}
+}
+
+func solve(n int) []int {
+	h1 := n / 3
+	h2 := (n*2 + 2) / 3
+
+	p := h1
+	for p < h2 && !checkPrime(p) {
+		p++
+	}
+	res := make([]int, n)
+	marked := make([]bool, n+1)
+	var pos int
+	for i := 0; p-i > 0 && p+i <= n && pos < n; i++ {
+		res[pos] = p - i
+		pos++
+		marked[p-i] = true
+		if pos < n && i > 0 {
+			res[pos] = p + i
+			pos++
+			marked[p+i] = true
+		}
+	}
+	for i := 1; pos < n; pos++ {
+		for marked[i] {
+			i++
+		}
+		res[pos] = i
+		marked[i] = true
+	}
+
+	return res
+}
+
+func checkPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	for i := 2; i*i <= n; i++ {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/src/codeforces/set2/set20/set208/set2089/a/solution_test.go
+++ b/src/codeforces/set2/set20/set208/set2089/a/solution_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func runSample(t *testing.T, n int) {
+	res := solve(n)
+
+	marked := make([]bool, n+1)
+	var sum int
+	var cnt int
+	for i, v := range res {
+		marked[v] = true
+		sum += v
+		avg := (sum + i) / (i + 1)
+		if checkPrime(avg) {
+			cnt++
+		}
+	}
+	if cnt < n/3-1 {
+		t.Fatalf("Sample result %v, is invalid, as it has only %d prime averages", res, cnt)
+	}
+	for i := 1; i <= n; i++ {
+		if !marked[i] {
+			t.Fatalf("Sample result %v, is invalid, as it does not contain %d", res, i)
+		}
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, 2)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 100)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 107)
+}

--- a/src/codeforces/set2/set20/set209/set2092/e/problem.md
+++ b/src/codeforces/set2/set20/set209/set2092/e/problem.md
@@ -1,0 +1,273 @@
+# E. She knows...
+
+Source: <https://codeforces.com/problemset/problem/2092/E>
+
+D. Pippy wants to repaint an `n x m` board for a black-and-white party.
+
+Initially, every cell is green except for `k` given cells. Each given cell is already painted either white or black.
+
+All remaining green cells must be repainted either white or black.
+
+After repainting, consider all unordered pairs of edge-adjacent cells with different colors. The requirement is that the number of such pairs must be even.
+
+Count how many ways there are to repaint all green cells so that this parity condition holds.
+
+Output the answer modulo:
+
+```text
+1_000_000_007
+```
+
+## Input
+
+The first line contains an integer `t`:
+
+```text
+1 <= t <= 10^4
+```
+
+Each test case starts with three integers:
+
+```text
+n m k
+```
+
+where:
+
+```text
+3 <= n, m <= 10^9
+1 <= k <= 2 * 10^5
+```
+
+Then follow `k` lines. Each line contains:
+
+```text
+x_i y_i c_i
+```
+
+where:
+
+```text
+1 <= x_i <= n
+1 <= y_i <= m
+c_i in {0, 1}
+```
+
+`c_i = 0` means the cell is white, and `c_i = 1` means the cell is black.
+
+All specified cells are distinct.
+
+It is guaranteed that the sum of `k` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output one integer:
+
+```text
+the number of valid repaintings modulo 1_000_000_007
+```
+
+## Example
+
+### Input
+
+```text
+2
+3 3 6
+1 1 0
+1 2 1
+1 3 0
+3 1 1
+3 2 0
+3 3 1
+3 4 12
+1 1 0
+1 2 1
+1 3 0
+1 4 1
+2 1 1
+2 2 0
+2 3 1
+2 4 0
+3 1 0
+3 2 1
+3 3 0
+3 4 1
+```
+
+### Output
+
+```text
+4
+0
+```
+
+## Notes
+
+In the first sample, there are exactly four valid ways to repaint the three green cells.
+
+In the second sample, all cells are already painted, and the number of adjacent pairs with different colors is odd, so the answer is `0`.
+
+### ideas
+1. 把剩余 n * m - k 个格子进行涂色（黑色或者白色), 保证在黑白格子中间的边的数量是偶数
+2. 完全想象不出来～
+3. 假设目前已经涂完色了，现在要将一个黑色变成白色。分情况考虑；
+4. 如果这个格子周围都是黑色格子，那么改变它的颜色， 贡献的边是偶数
+5. 如果这个格子周围只有一个白色格子, 贡献的边还是偶数（减少了一条边，但是增加了3条边）
+6. 如果这个格子周围有两个白色格子，贡献是0，减少了2条边，但是增加了2条边
+7. 如果这个格子周围有3个白色格子，贡献也是偶数，减少了3条边，但是增加了2条边（所以，在内部的格子的颜色，其实是没有影响的）pow(2, (n - 2) * (m - 2) - k1) 
+8. 然后考虑在边上的格子（不在corner中的）
+9. 如果它的周围都是黑色格子，那么翻转它，边的奇偶性变化了（+3条边）
+10. 如果它的周围有两个黑色格子（都在左右）翻转后，变化是+1（+2了两条边，-1了一条边）
+11. 如果它的周围是一个黑色格子，翻转后，变化是-1， 少了两条边，+1了一条边
+12. 如果它的周围都是白色格子，翻转后，变化是-3
+13. 现在考虑corner的情况，如果翻转它，没有变化（不管它靠近的是黑色还是白色，不影响结构）
+14. pow(2, (n - 2) * (m - 2) + 4) （不影响结果的部分）
+15. 怎么得到偶数的边呢？且全部绿色都变成了黑色的情况下，边是偶数，那么必须翻转偶数个点（剩余部分的偶数个）
+16. pow(2, m - 1)不管怎么如何都是这样子的（留下最后一个点，调整就可以）
+17. 和现有的颜色没有关系
+
+## Solution explanation
+
+Use `0/1` to represent the two colors.
+
+For an edge `(u, v)`, this edge contributes `1` to the count of different-color adjacent pairs exactly when:
+
+```text
+color[u] xor color[v] = 1
+```
+
+We only care about whether the total count is even or odd, so work modulo `2`:
+
+```text
+sum over edges (color[u] xor color[v])
+```
+
+For bits, `xor` is the same as addition modulo `2`:
+
+```text
+color[u] xor color[v] = color[u] + color[v] (mod 2)
+```
+
+So the parity of all bad edges is:
+
+```text
+sum over edges (color[u] + color[v])
+```
+
+Every cell color appears once for each incident edge. Therefore:
+
+```text
+bad_edge_parity = sum over cells color[cell] * degree[cell] (mod 2)
+```
+
+Only cells with odd degree matter.
+
+## Which cells matter
+
+For a normal `n x m` rectangle:
+
+- inner cells have degree `4`, so they do not affect parity;
+- corner cells have degree `2`, so they do not affect parity;
+- boundary non-corner cells have degree `3`, so they do affect parity.
+
+The code counts these groups as:
+
+```go
+inner = (n - 2) * (m - 2)
+corner = 4
+other = 2*(n-2) + 2*(m-2)
+```
+
+Then it subtracts the already fixed cells from the corresponding group.
+
+Here `other` means unpainted boundary non-corner cells, i.e. unpainted odd-degree cells.
+
+## Free cells
+
+Unpainted even-degree cells never affect the parity condition. They can be colored arbitrarily.
+
+So they contribute:
+
+```text
+2^(inner + corner)
+```
+
+This is:
+
+```go
+res := pow(2, inner+corner)
+```
+
+## If there is at least one unpainted odd-degree cell
+
+The odd-degree unpainted cells are the only remaining variables in the parity equation.
+
+If there are `other > 0` such variables, exactly half of their assignments satisfy the required parity. We can choose all but one arbitrarily, and the last one is forced.
+
+So their contribution is:
+
+```text
+2^(other - 1)
+```
+
+The answer is:
+
+```go
+res * pow(2, other-1)
+```
+
+This case does not need to inspect the fixed colors, because the final odd-degree unpainted cell can always adjust the parity.
+
+## If all odd-degree cells are fixed
+
+When `other == 0`, no variable can adjust the parity. We must directly check whether the currently forced coloring has even bad-edge parity.
+
+The code treats every still-unpainted cell as black. This is safe in this branch because all remaining unpainted cells have even degree, so changing any of them would not affect the parity.
+
+Then it counts bad edges involving fixed cells:
+
+- `cnt` counts edges between a fixed cell and an unpainted black neighbor that have different colors;
+- `cnt2` counts edges between two fixed cells of different colors.
+
+The fixed-fixed edges are seen from both endpoints, so:
+
+```go
+cnt2 /= 2
+```
+
+Finally:
+
+```go
+cnt += cnt2
+```
+
+If `cnt` is odd, no assignment works:
+
+```go
+return 0
+```
+
+Otherwise all even-degree unpainted cells are free, so the answer is still:
+
+```go
+2^(inner + corner)
+```
+
+## Complexity
+
+For each test case, the algorithm only processes the `k` fixed cells and checks their four neighbors.
+
+Time complexity:
+
+```text
+O(k log k)
+```
+
+because the implementation stores fixed cells in a map.
+
+Memory complexity:
+
+```text
+O(k)
+```

--- a/src/codeforces/set2/set20/set209/set2092/e/solution.go
+++ b/src/codeforces/set2/set20/set209/set2092/e/solution.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, m, k int
+	fmt.Fscan(reader, &n, &m, &k)
+	a := make([][]int, k)
+	for i := range k {
+		a[i] = make([]int, 3)
+		fmt.Fscan(reader, &a[i][0], &a[i][1], &a[i][2])
+	}
+	return solve(n, m, a)
+}
+
+const mod = 1_000_000_007
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return a * b % mod
+}
+
+func pow(a, b int) int {
+	res := 1
+	for b > 0 {
+		if b&1 == 1 {
+			res = mul(res, a)
+		}
+		a = mul(a, a)
+		b >>= 1
+	}
+	return res
+}
+
+func solve(n int, m int, a [][]int) int {
+	if n*m == 1 {
+		if len(a) == 0 {
+			return 2
+		}
+		return 1
+	}
+	var inner int
+	var corner int
+	var other int
+
+	if n >= 2 && m >= 2 {
+		inner = (n - 2) * (m - 2)
+		corner = 4
+		other = 2*(n-2) + 2*(m-2)
+	} else if n == 1 {
+		inner = 0
+		corner = 2
+		other = m - 2
+	} else {
+		// m == 1
+		inner = 0
+		corner = 2
+		other = n - 2
+	}
+
+	for _, cur := range a {
+		r, c := cur[0]-1, cur[1]-1
+		if r > 0 && r < n-1 && c > 0 && c < m-1 {
+			inner--
+		} else if r == 0 && c == 0 || r == 0 && c == m-1 || r == n-1 && c == 0 || r == n-1 && c == m-1 {
+			corner--
+		} else {
+			other--
+		}
+	}
+
+	res := pow(2, inner+corner)
+	if other > 0 {
+		return mul(res, pow(2, other-1))
+	}
+	type pair struct {
+		first  int
+		second int
+	}
+	marked := make(map[pair]int)
+
+	for _, cur := range a {
+		marked[pair{cur[0], cur[1]}] = cur[2]
+	}
+
+	// 绿色的都当作黑色处理
+	checkEmpty := func(r int, c int, color int) bool {
+		if color == 0 {
+			return false
+		}
+		// 这个格子是空的
+		if _, ok := marked[pair{r, c}]; !ok {
+			return true
+		}
+		return false
+	}
+
+	checkDifferent := func(r int, c int, color int) bool {
+		if c2, ok := marked[pair{r, c}]; ok && c2 != color {
+			return true
+		}
+		return false
+	}
+
+	var cnt int
+	var cnt2 int
+	for _, cur := range a {
+		r, c, color := cur[0], cur[1], cur[2]
+		if r > 1 && checkEmpty(r-1, c, color) {
+			cnt++
+		}
+		if r < n && checkEmpty(r+1, c, color) {
+			cnt++
+		}
+
+		if c > 1 && checkEmpty(r, c-1, color) {
+			cnt++
+		}
+		if c < m && checkEmpty(r, c+1, color) {
+			cnt++
+		}
+
+		if r > 1 && checkDifferent(r-1, c, color) {
+			cnt2++
+		}
+
+		if r < n && checkDifferent(r+1, c, color) {
+			cnt2++
+		}
+		if c > 1 && checkDifferent(r, c-1, color) {
+			cnt2++
+		}
+		if c < m && checkDifferent(r, c+1, color) {
+			cnt2++
+		}
+	}
+	cnt2 /= 2
+
+	cnt += cnt2
+
+	if cnt%2 == 1 {
+		return 0
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set20/set209/set2092/e/solution_test.go
+++ b/src/codeforces/set2/set20/set209/set2092/e/solution_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3 3 6
+1 1 0
+1 2 1
+1 3 0
+3 1 1
+3 2 0
+3 3 1`
+	expect := 4
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3 4 12
+1 1 0
+1 2 1
+1 3 0
+1 4 1
+2 1 1
+2 2 0
+2 3 1
+2 4 0
+3 1 0
+3 2 1
+3 3 0
+3 4 1`
+	expect := 0
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set20/set209/set2094/f/problem.md
+++ b/src/codeforces/set2/set20/set209/set2094/f/problem.md
@@ -1,0 +1,184 @@
+# F. Trulimero Trulicina
+
+Source: <https://codeforces.com/problemset/problem/2094/F>
+
+You are given integers `n`, `m`, and `k`.
+
+It is guaranteed that:
+
+- `k >= 2`;
+- `n * m` is divisible by `k`.
+
+Construct an `n x m` grid of integers satisfying all of the following:
+
+- every cell contains an integer from `1` to `k`;
+- each integer from `1` to `k` appears exactly the same number of times;
+- no two edge-adjacent cells contain the same integer.
+
+It is guaranteed that at least one valid grid always exists. If there are multiple valid grids, output any one of them.
+
+## Input
+
+The first line contains an integer `t`:
+
+```text
+1 <= t <= 10^4
+```
+
+Each test case contains one line with three integers:
+
+```text
+n m k
+```
+
+Constraints:
+
+```text
+2 <= n * m <= 2 * 10^5
+2 <= k <= n * m
+n * m ≡ 0 (mod k)
+```
+
+It is guaranteed that the sum of `n * m` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output `n` lines.
+
+Each line should contain `m` integers, describing a valid grid.
+
+Any valid grid is accepted.
+
+## Example
+
+### Input
+
+```text
+3
+2 2 2
+3 4 6
+5 5 25
+```
+
+### Output
+
+```text
+1 2
+2 1
+1 6 1 6
+2 5 2 5
+3 4 3 4
+17 2 12 25 14
+3 1 6 19 11
+8 20 23 24 4
+9 10 5 13 21
+22 7 15 18 16
+```
+
+## Notes
+
+The output is not unique. The sample output is only one possible construction.
+
+### ideas
+1. (n * m) % k = 0 
+2. 一共是 n * m 个格子，所以每个数出现的次数 = n * m / k
+3. 相邻的格子不能有相同的数
+4. 那么就斜着铺？
+
+## Solution explanation
+
+Since `n * m` is divisible by `k`, let:
+
+```text
+blocks = n * m / k
+```
+
+If we fill the cells in row-major order and every consecutive block of `k` cells contains each value `1..k` exactly once, then every value appears exactly `blocks` times.
+
+So the main construction is:
+
+```text
+s+1, s+2, ..., s+k   modulo k
+```
+
+for each block of `k` cells.
+
+In code, for a block starting with offset `s`:
+
+```go
+for x := range k {
+	res[r][c] = (s+x)%k + 1
+	pos++
+}
+```
+
+This guarantees equal frequencies, because every block contains all `k` values exactly once.
+
+## Why horizontal neighbors are safe
+
+Inside one block, consecutive cells get consecutive values modulo `k`.
+
+Because `k >= 2`, two consecutive values inside the block are never equal.
+
+At the boundary between two blocks, the code chooses the next block's starting offset `s` so that the new value at the next cell is not equal to the left neighbor.
+
+So horizontal adjacency is handled by the same offset check.
+
+## Why vertical neighbors only need the first cell check
+
+When a new block starts, the code chooses its first value:
+
+```go
+s%k + 1
+```
+
+and checks whether this value conflicts with:
+
+- the cell above;
+- the cell to the left.
+
+```go
+if (r == 0 || res[r-1][c] != s%k+1) &&
+   (c == 0 || res[r][c-1] != s%k+1) {
+	break
+}
+```
+
+After the first cell of the block is valid, the rest of the block is valid too.
+
+The reason is that both the current block and the row-major cells above it advance by `+1 modulo k` as we move to the right through the block. If the first pair of vertically adjacent cells differs, then adding the same offset to both sides keeps them different.
+
+So a vertical conflict inside the block would imply a vertical conflict at the first checked cell of the block.
+
+## Why a valid offset always exists
+
+For the first cell of a block, at most two values are forbidden:
+
+- the value directly above;
+- the value directly to the left.
+
+We need to choose one value from `1..k`.
+
+If `k > 2`, at least one value is always available immediately.
+
+If `k = 2`, there may appear to be two forbidden values. In that case the two forbidden values come from the above and left cells. The row-major block structure and the condition `n * m` divisible by `k` still ensure that shifting the starting offset eventually finds a valid start; the implementation simply increments `s` until the condition passes.
+
+The constraints guarantee that a solution exists, and this loop finds a suitable cyclic offset for each block.
+
+## Complexity
+
+Each cell is written exactly once.
+
+The offset `s` only increases when a candidate start value is rejected; since it is checked modulo `k`, this is constant amortized work per block.
+
+Time complexity:
+
+```text
+O(n * m)
+```
+
+Memory complexity:
+
+```text
+O(n * m)
+```

--- a/src/codeforces/set2/set20/set209/set2094/f/solution.go
+++ b/src/codeforces/set2/set20/set209/set2094/f/solution.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var n, m, k int
+		fmt.Fscan(reader, &n, &m, &k)
+		res := solve(n, m, k)
+		for i := range n {
+			for j := range m {
+				fmt.Fprint(writer, res[i][j], " ")
+			}
+			fmt.Fprintln(writer)
+		}
+	}
+}
+
+func solve(n int, m int, k int) [][]int {
+	res := make([][]int, n)
+	for i := range n {
+		res[i] = make([]int, m)
+	}
+
+	var s int
+	for pos := 0; pos < n*m; {
+		for x := range k {
+			r, c := pos/m, pos%m
+			res[r][c] = (s+x)%k + 1
+			pos++
+		}
+		if pos == n*m {
+			break
+		}
+		for {
+			r, c := pos/m, pos%m
+			if (r == 0 || res[r-1][c] != s%k+1) && (c == 0 || res[r][c-1] != s%k+1) {
+				break
+			}
+			s++
+		}
+	}
+
+	return res
+}

--- a/src/codeforces/set2/set20/set209/set2094/f/solution_test.go
+++ b/src/codeforces/set2/set20/set209/set2094/f/solution_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func runSample(t *testing.T, n int, m int, k int) {
+	cnt := make([]int, k)
+
+	res := solve(n, m, k)
+
+	for i := range n {
+		for j := range m {
+			if i > 0 && res[i-1][j] == res[i][j] {
+				t.Fatalf("Sample result %v, not correct", res)
+			}
+			if j > 0 && res[i][j-1] == res[i][j] {
+				t.Fatalf("Sample result %v, not correct", res)
+			}
+			cnt[res[i][j]-1]++
+		}
+	}
+	x := slices.Min(cnt)
+	y := slices.Max(cnt)
+	if x != y {
+		t.Fatalf("Sample result %v, not correct", res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, 2, 2, 2)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 3, 4, 6)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 2, 3, 3)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, 1, 4, 2)
+}
+
+func TestSample5(t *testing.T) {
+	runSample(t, 2, 3, 2)
+}
+
+func TestSample6(t *testing.T) {
+	/**
+	1 2
+	3 2
+	3 1
+	*/
+	runSample(t, 3, 2, 3)
+}

--- a/src/codeforces/set2/set21/set213/set2137/f/problem.md
+++ b/src/codeforces/set2/set21/set213/set2137/f/problem.md
@@ -1,0 +1,266 @@
+Given two arrays `x` and `y`, both of size `m`, let `z` be another array of size `m` such that the prefix maximum at each position of `z` is the same as the prefix maximum at each position of `x`.
+
+Formally, for all `1 <= i <= m`:
+
+`max(x1, x2, ..., xi) = max(z1, z2, ..., zi)`
+
+Define `f(x, y)` to be the maximum number of positions where `zi = yi` over all possible arrays `z`.
+
+You are given two sequences of integers `a` and `b`, both of size `n`. Find the value of:
+
+`sum_{l=1..n} sum_{r=l..n} f([al, al+1, ..., ar], [bl, bl+1, ..., br])`
+
+## Input
+
+Each test contains multiple test cases.
+
+- The first line contains the number of test cases `t` (`1 <= t <= 10^4`).
+- The description of the test cases follows.
+
+For each test case:
+
+- The first line contains an integer `n` (`1 <= n <= 2 * 10^5`).
+- The second line contains `n` integers `a1, a2, ..., an` (`1 <= ai <= 2 * n`).
+- The third line contains `n` integers `b1, b2, ..., bn` (`1 <= bi <= 2 * n`).
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, output:
+
+`sum_{l=1..n} sum_{r=l..n} f([al, al+1, ..., ar], [bl, bl+1, ..., br])`
+
+over all pairs `(l, r)`.
+
+## Example
+
+### Input
+
+```text
+6
+3
+5 3 1
+4 2 1
+5
+1 2 3 4 5
+1 2 3 4 5
+6
+7 1 12 10 5 8
+9 2 4 3 6 5
+1
+1
+2
+6
+5 1 2 6 3 4
+3 1 6 5 2 4
+2
+2 2
+1 1
+```
+
+### Output
+
+```text
+5
+35
+26
+0
+24
+1
+```
+
+## Note
+
+In the first test case, the answer is the sum of the following:
+
+- `f([5], [4]) = 0`, using `z = [5]`.
+- `f([3], [2]) = 0`, using `z = [3]`.
+- `f([1], [1]) = 1`, using `z = [1]`.
+- `f([5, 3], [4, 2]) = 1`, using `z = [5, 2]`.
+- `f([3, 1], [2, 1]) = 1`, using `z = [3, 1]`.
+- `f([5, 3, 1], [4, 2, 1]) = 2`, using `z = [5, 2, 1]`.
+
+
+### ideas
+1. 在给定(x, y)的情况下，可以先计算出w
+2. w[0] = x[0], w[1] = max(w[0], x[1]), .. w[i] = max(w[i-1], x[i]), ...
+3. 如果y[i] <= w[i-1], 那么+1, 否则+0, 这时候z[i] = y[i], 不会改变w的结果; 否则就不一致了
+4. 
+
+## Solution explanation
+
+For one fixed subarray `x = a[l..r]`, define its required prefix maximum sequence:
+
+```text
+w[i] = max(x[0], x[1], ..., x[i])
+```
+
+We need to choose another array `z` such that its prefix maxima are exactly `w`, and we want as many positions as possible where `z[i] = y[i]`.
+
+Consider one position `i`.
+
+Before this position, the prefix maximum is:
+
+```text
+prev = max(x[0], ..., x[i-1])
+```
+
+If we set `z[i] = y[i]`, then the new prefix maximum of `z` becomes:
+
+```text
+max(prev, y[i])
+```
+
+The required prefix maximum from `x` is:
+
+```text
+max(prev, x[i])
+```
+
+So position `i` can match `y[i]` exactly when:
+
+```text
+max(prev, y[i]) = max(prev, x[i])
+```
+
+There are two cases.
+
+### Case 1: `x[i] = y[i]`
+
+Then the equality is always true:
+
+```text
+max(prev, y[i]) = max(prev, x[i])
+```
+
+So this position contributes `1` for every subarray containing it.
+
+### Case 2: `x[i] != y[i]`
+
+Then the only way the two maxima are equal is if both values are hidden below the previous maximum:
+
+```text
+prev >= max(x[i], y[i])
+```
+
+In this case, setting `z[i] = y[i]` does not change the prefix maximum, and the required prefix maximum also does not change.
+
+If `prev < max(x[i], y[i])`, then one of `x[i]` or `y[i]` becomes the new prefix maximum while the other does not, so matching is impossible.
+
+## Summing by position
+
+Instead of evaluating every subarray separately, count the contribution of each global position `r`.
+
+If position `r` contributes to a subarray `[l..R]`, then the right endpoint `R` can be anything from `r` to `n-1`. That gives:
+
+```text
+n - r
+```
+
+choices for the right endpoint.
+
+So we only need to count how many left endpoints `l <= r` make position `r` matchable.
+
+## When `a[r] = b[r]`
+
+This is always matchable for every left endpoint.
+
+There are `r + 1` choices for `l`, and `n - r` choices for `R`, so the contribution is:
+
+```go
+(r + 1) * (n - r)
+```
+
+This matches the code:
+
+```go
+if x[r] == y[r] {
+	res += (r + 1) * (n - r)
+}
+```
+
+## When `a[r] != b[r]`
+
+We need:
+
+```text
+max(a[l..r-1]) >= max(a[r], b[r])
+```
+
+Let:
+
+```text
+need = max(a[r], b[r])
+```
+
+For a fixed `r`, suppose the latest index before `r` with `a[index] >= need` is `p`.
+
+Then:
+
+- if `l <= p`, the prefix `a[l..r-1]` contains that large enough value, so position `r` is matchable;
+- if `l > p`, no previous value in the subarray is large enough, so it is not matchable.
+
+Therefore the number of valid left endpoints is:
+
+```text
+p + 1
+```
+
+and the total contribution of position `r` is:
+
+```go
+(p + 1) * (n - r)
+```
+
+## Segment tree
+
+While scanning `r` from left to right, the code maintains previous `a` values in a segment tree.
+
+At value `v`, the tree stores the largest index seen so far with:
+
+```text
+a[index] = v
+```
+
+To find the latest previous index with value at least `need`, query the range:
+
+```go
+[need, 2*n+1)
+```
+
+This returns:
+
+```go
+l := tr.Get(max(x[r], y[r]), 2*n+1)
+```
+
+Then the contribution is:
+
+```go
+res += (l + 1) * (n - r)
+```
+
+After processing position `r`, insert `a[r]` into the segment tree:
+
+```go
+tr.Update(x[r], r)
+```
+
+This order is important: for the non-equal case, position `r` needs a previous maximum from `a[l..r-1]`, so `a[r]` itself must not be included in the query.
+
+## Complexity
+
+Each position does one range-maximum query and one point update on values up to `2n`.
+
+Time complexity:
+
+```text
+O(n log n)
+```
+
+Memory complexity:
+
+```text
+O(n)
+```

--- a/src/codeforces/set2/set21/set213/set2137/f/solution.go
+++ b/src/codeforces/set2/set21/set213/set2137/f/solution.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	x := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &x[i])
+	}
+	y := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &y[i])
+	}
+	return solve(x, y)
+}
+
+func solve(x []int, y []int) int {
+	n := len(x)
+	// x[i] <= 2 * n
+	tr := NewSegTree(2*n + 1)
+
+	var res int
+	for r := range n {
+		// 左边最大的l, x[l] >= y[r]
+		if x[r] == y[r] {
+			res += (r + 1) * (n - r)
+		} else {
+			l := tr.Get(max(x[r], y[r]), 2*n+1)
+			res += (l + 1) * (n - r)
+		}
+		tr.Update(x[r], r)
+	}
+
+	return res
+}
+
+type SegTree []int
+
+func NewSegTree(n int) SegTree {
+	res := make(SegTree, 2*n)
+	for i := 0; i < len(res); i++ {
+		res[i] = -1
+	}
+	return res
+}
+
+func (t SegTree) Update(p int, v int) {
+	n := len(t) / 2
+	p += n
+	if t[p] >= v {
+		return
+	}
+	t[p] = v
+	for p > 1 {
+		t[p>>1] = max(t[p], v)
+		p >>= 1
+	}
+}
+
+func (t SegTree) Get(l int, r int) int {
+	n := len(t) / 2
+	l += n
+	r += n
+	res := -1
+	for l < r {
+		if l&1 == 1 {
+			res = max(res, t[l])
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			res = max(res, t[r])
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}

--- a/src/codeforces/set2/set21/set213/set2137/f/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2137/f/solution_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3
+5 3 1
+4 2 1`
+	expect := 5
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5
+1 2 3 4 5
+1 2 3 4 5`
+	expect := 35
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `6
+7 1 12 10 5 8
+9 2 4 3 6 5`
+	// y[2]的贡献 = 0
+	// 
+	expect := 26
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `1
+1
+2`
+
+	expect := 0
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `6
+5 1 2 6 3 4
+3 1 6 5 2 4`
+
+	expect := 24
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set213/set2137/g/problem.md
+++ b/src/codeforces/set2/set21/set213/set2137/g/problem.md
@@ -1,0 +1,332 @@
+There is a directed acyclic graph with `n` nodes and `m` edges. Each node is initially colored blue.
+
+## Fun graph game
+
+A token starts on node `s`. Cry and River take turns moving the token along a directed edge to an adjacent node, with Cry going first.
+
+- **Cry wins** if the token ever reaches a node with no outgoing edges (after either player's turn).
+- **River wins** if the token reaches a red node (after either player's turn).
+- If the token reaches a node that is both red and has no outgoing edges, **River wins**.
+
+Since the graph is acyclic, the game always ends in a finite number of turns.
+
+Cry or River can win immediately if the starting node `s` has no outgoing edges, or is red, respectively.
+
+## Queries
+
+You must handle `q` queries:
+
+- `1 u`: update the color of node `u` to red. It is guaranteed that node `u` was blue before this update.
+- `2 u`: if a fun graph game is played with the token initially at node `u`, and both players play optimally, does Cry win?
+
+## Input
+
+Each test contains multiple test cases.
+
+- The first line contains the number of test cases `t` (`1 <= t <= 10^4`). The description of the test cases follows.
+
+For each test case:
+
+- The first line contains three integers `n`, `m`, `q` (`2 <= n <= 2 * 10^5`, `1 <= m, q <= 2 * 10^5`).
+- The next `m` lines each contain two integers `u` and `v` (`1 <= u, v <= n`), meaning there is a directed edge from `u` to `v`.
+- The next `q` lines each contain two integers `x` and `u` (`1 <= x <= 2`, `1 <= u <= n`) — the query type and the node.
+
+It is guaranteed that the graph is a directed acyclic graph, and that no edge appears more than once.
+
+It is guaranteed that the sum of `n`, the sum of `m`, and the sum of `q` over all test cases each do not exceed `2 * 10^5`.
+
+## Output
+
+For each query of the second type, output `YES` if Cry wins; otherwise output `NO`. Letters may be in uppercase or lowercase.
+
+## Example
+
+### Input
+
+```text
+1
+7 8 10
+1 2
+1 3
+1 4
+2 5
+3 6
+5 7
+2 3
+3 4
+2 1
+1 3
+1 4
+2 1
+2 2
+2 3
+2 4
+2 5
+2 6
+2 7
+```
+
+### Output
+
+```text
+YES
+NO
+YES
+NO
+NO
+YES
+YES
+YES
+YES
+```
+
+## Note
+
+Below is the graph from the sample.
+
+Initially, all nodes are blue. Cry cannot lose, and eventually the token is moved to a node without outgoing edges.
+
+After nodes `3` and `4` are painted red, nodes `1`, `3`, and `4` are a win for River under optimal play. If the game starts at nodes `3` or `4`, River wins immediately. If the game starts at node `1`, one possible play is:
+
+- Cry moves the token to node `2`.
+- River moves the token to node `3`, which is red, so River wins.
+
+It can be shown that Cry still wins with optimal play for all other starting nodes.
+
+### ideas
+1. River获胜的条件是，进入一个Red节点，
+2. 如果River不能获胜，那么是Cry获胜。所以问题的关键就是看从一个节点u出发，无论Cry怎么选择，都会进入一个Red节点。
+3. 这是一个DAG, 
+4. 那么对于u，什么情况下，肯定会走到red节点呢？
+5. 如果一个节点u已经是一个失败节点（river胜出），那么它就一直是一个失败节点
+6. 但是如果是一个胜利节点，后面有可能还是会变成失败节点
+7. 那么如果从u出发，只能到达失败节点，那么u也是失败节点。或者到达v节点后，可以到达失败节点，（v不一定是失败节点）但是u肯定是失败节点
+8. 想不出来～
+
+## Detailed solution
+
+The graph is a DAG, so every game ends. Since River wins immediately when the token reaches a red node, and Cry wins immediately when the token reaches a sink, every state is either winning for Cry or winning for River.
+
+The updates only paint blue nodes red. Red nodes never become blue again. So as time goes on, the game can only become worse for Cry. This monotonicity is the key: a state can change from "Cry wins" to "Cry loses", but never in the other direction.
+
+## Two DP states
+
+For each node `u`, maintain two booleans:
+
+```text
+dp1[u] = whether Cry wins if the token is at u and it is Cry's turn
+dp2[u] = whether Cry wins if the token is at u and it is River's turn
+```
+
+The query `2 u` asks about a game starting at `u` with Cry moving first, so the answer is exactly:
+
+```text
+dp1[u]
+```
+
+Initially every node is blue. In that initial graph, Cry can always win, because the game must eventually reach a sink and there are no red nodes. Therefore:
+
+```text
+dp1[u] = true
+dp2[u] = true
+```
+
+for every node `u`.
+
+When nodes become red, some of these states turn false.
+
+## Game transitions
+
+Let there be an edge:
+
+```text
+v -> u
+```
+
+Think about how losing states propagate backwards through this edge.
+
+### If `dp1[u]` becomes false
+
+This means:
+
+```text
+if the token is at u and it is Cry's turn, Cry loses.
+```
+
+Now consider predecessor `v` when it is River's turn. River can move from `v` to `u`. After that move, the token is at `u` and it is Cry's turn, which is losing for Cry.
+
+So River has a move that makes Cry lose. Therefore:
+
+```text
+dp2[v] = false
+```
+
+This is why the code handles a popped state `(u, 1)` by setting all reverse-neighbors' `dp2` to false:
+
+```go
+if w == 1 {
+	for _, v := range adj[u] {
+		if dp2[v] {
+			dp2[v] = false
+			que[head] = data{v, 2}
+			head++
+		}
+	}
+}
+```
+
+Here `adj[u]` stores predecessors of `u`, because the input edges were reversed when building `adj`.
+
+### If `dp2[u]` becomes false
+
+This means:
+
+```text
+if the token is at u and it is River's turn, Cry loses.
+```
+
+Now consider predecessor `v` when it is Cry's turn. Cry chooses one outgoing edge from `v`.
+
+Cry wins from `v` only if he has at least one move to a child where Cry still wins on River's turn. In other words:
+
+```text
+dp1[v] = true if there exists child u with dp2[u] = true
+```
+
+So `dp1[v]` becomes false only when every outgoing child of `v` has `dp2[child] = false`.
+
+The code maintains:
+
+```text
+cnt[v] = number of outgoing children child of v with dp2[child] = false
+deg[v] = total outdegree of v
+```
+
+When a child `u` changes to `dp2[u] = false`, all predecessors `v` increment `cnt[v]`. If now:
+
+```text
+cnt[v] == deg[v]
+```
+
+then every move from `v` goes to a losing state for Cry, so:
+
+```text
+dp1[v] = false
+```
+
+This is the second propagation rule in the code:
+
+```go
+if w == 2 {
+	for _, v := range adj[u] {
+		cnt[v]++
+		if cnt[v] == deg[v] && dp1[v] {
+			dp1[v] = false
+			que[head] = data{v, 1}
+			head++
+		}
+	}
+}
+```
+
+## Painting a node red
+
+When query `1 s` paints node `s` red, River wins immediately if the token is at `s`, regardless of whose turn it is. Therefore both states become losing for Cry:
+
+```text
+dp1[s] = false
+dp2[s] = false
+```
+
+Then the two reverse propagation rules above may make more states losing.
+
+The code performs this with a queue:
+
+```go
+que := make([]data, n*2)
+```
+
+Each queue item is:
+
+```go
+type data struct {
+	id    int
+	state int
+}
+```
+
+where:
+
+- `state = 1` means `dp1[id]` just became false;
+- `state = 2` means `dp2[id]` just became false.
+
+The `flip(s)` function starts by enqueueing the states of `s` that newly became false, then processes the queue until no more states change.
+
+## Why the guard in `flip` is necessary
+
+This part is subtle.
+
+Even if node `s` was still blue, one or both of its DP states may already be false because of previously painted red nodes reachable from it.
+
+For example, a blue node can already be losing for Cry if River can force the token into an earlier red node.
+
+So when `s` is painted red, we must not blindly enqueue both states. We should enqueue only the states that actually change from true to false:
+
+```go
+if dp1[s] {
+	dp1[s] = false
+	que[head] = data{s, 1}
+	head++
+}
+if dp2[s] {
+	dp2[s] = false
+	que[head] = data{s, 2}
+	head++
+}
+```
+
+This is required for correctness, not only for speed.
+
+If `dp2[u]` is propagated twice, then every predecessor `v` increments `cnt[v]` twice for the same child `u`. Then `cnt[v] == deg[v]` may become true even though not all children of `v` are losing. That would incorrectly set `dp1[v] = false`.
+
+So the invariant is:
+
+```text
+each state dp1[u] / dp2[u] is enqueued exactly once, when it changes true -> false
+```
+
+With that invariant, `cnt[v]` really counts distinct outgoing children whose `dp2` state is false.
+
+## Why this is efficient
+
+Every state can change only once:
+
+```text
+dp1[u]: true -> false
+dp2[u]: true -> false
+```
+
+There are only `2n` such changes.
+
+When a state changes, the algorithm scans the reverse adjacency list of that node. Across the whole test case:
+
+- each edge is scanned at most once due to a `dp1` change;
+- each edge is scanned at most once due to a `dp2` change.
+
+Therefore the total propagation cost is:
+
+```text
+O(n + m)
+```
+
+Handling all queries adds `O(q)`, so the total complexity is:
+
+```text
+O(n + m + q)
+```
+
+The memory usage is:
+
+```text
+O(n + m)
+```

--- a/src/codeforces/set2/set21/set213/set2137/g/solution.go
+++ b/src/codeforces/set2/set21/set213/set2137/g/solution.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		for _, cur := range res {
+			if cur {
+				fmt.Fprintln(writer, "YES")
+			} else {
+				fmt.Fprintln(writer, "NO")
+			}
+		}
+	}
+}
+
+func drive(reader *bufio.Reader) []bool {
+	var n, m, q int
+	fmt.Fscan(reader, &n, &m, &q)
+	edges := make([][]int, m)
+	for i := range m {
+		edges[i] = make([]int, 2)
+		fmt.Fscan(reader, &edges[i][0], &edges[i][1])
+	}
+	queries := make([][]int, q)
+	for i := range q {
+		queries[i] = make([]int, 2)
+		fmt.Fscan(reader, &queries[i][0], &queries[i][1])
+	}
+	return solve(n, edges, queries)
+}
+
+type data struct {
+	id    int
+	state int
+}
+
+func solve(n int, edges [][]int, queries [][]int) []bool {
+	adj := make([][]int, n)
+	deg := make([]int, n)
+	// cnt[u] 表示有多少个后继节点，dp2[v] = false（如果到了这些节点，因为是River操作）
+	cnt := make([]int, n)
+	dp1 := make([]bool, n)
+	dp2 := make([]bool, n)
+	// dp1[i] 表示在节点i，且Cry操作时，cry是否可以获胜
+	// dp2[i] 表示在节点i，且目前由River操作时，Cry是否可以获胜
+	for i := range n {
+		dp1[i] = true
+		dp2[i] = true
+	}
+
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		adj[v] = append(adj[v], u)
+		deg[u]++
+	}
+
+	que := make([]data, n*2)
+
+	flip := func(s int) {
+		var head, tail int
+		if dp1[s] {
+			dp1[s] = false
+			que[head] = data{s, 1}
+			head++
+		}
+		if dp2[s] {
+			dp2[s] = false
+			que[head] = data{s, 2}
+			head++
+		}
+
+		for tail < head {
+			u, w := que[tail].id, que[tail].state
+			tail++
+
+			if w == 1 {
+				// 如果在节点u处，即使Cry操作，也是失败的，那么它所有的前继节点, dp2[v] = false
+				for _, v := range adj[u] {
+					if dp2[v] == true {
+						dp2[v] = false
+						que[head] = data{v, 2}
+						head++
+					}
+				}
+			}
+			if w == 2 {
+				for _, v := range adj[u] {
+					cnt[v]++
+					// 如果它的所有后继节点都是失败节点
+					if cnt[v] == deg[v] && dp1[v] == true {
+						dp1[v] = false
+						que[head] = data{v, 1}
+						head++
+					}
+				}
+			}
+		}
+	}
+
+	var ans []bool
+
+	for _, cur := range queries {
+		if cur[0] == 1 {
+			flip(cur[1] - 1)
+		} else {
+			u := cur[1] - 1
+			ans = append(ans, dp1[u])
+		}
+	}
+
+	return ans
+}

--- a/src/codeforces/set2/set21/set213/set2137/g/solution_test.go
+++ b/src/codeforces/set2/set21/set213/set2137/g/solution_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect []bool) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if !slices.Equal(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `7 8 10
+1 2
+1 3
+1 4
+2 5
+3 6
+5 7
+2 3
+3 4
+2 1
+1 3
+1 4
+2 1
+2 2
+2 3
+2 4
+2 5
+2 6
+2 7`
+	expect := []bool{
+		true,
+		false,
+		true,
+		false,
+		false,
+		true,
+		true,
+		true,
+	}
+	runSample(t, s, expect)
+}
+
+func TestPaintingAlreadyLosingBlueNodeDoesNotDoubleCount(t *testing.T) {
+	s := `4 3 4
+1 2
+2 3
+1 4
+1 3
+2 1
+1 2
+2 1`
+	expect := []bool{true, true}
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- Add new Codeforces problem statements, solutions, and tests for 2089A, 2092E, 2094F, and 2137 F/G.
- Normalize and format the newly added problem markdown files for readability and consistency.
- Include a related update to the existing Codeforces 1303E solution file in the same commit.

## Test plan
- [ ] Run `go test ./src/codeforces/set2/set20/set208/set2089/a/`
- [ ] Run `go test ./src/codeforces/set2/set20/set209/set2092/e/`
- [ ] Run `go test ./src/codeforces/set2/set20/set209/set2094/f/`
- [ ] Run `go test ./src/codeforces/set2/set21/set213/set2137/f/`
- [ ] Run `go test ./src/codeforces/set2/set21/set213/set2137/g/`

Made with [Cursor](https://cursor.com)