### PR TITLE
Add LeetCode 3921–3928 and Codeforces 2153 C/D

### DIFF
--- a/src/codeforces/set2/set21/set215/set2153/c/solution.go
+++ b/src/codeforces/set2/set21/set215/set2153/c/solution.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+func solve(a []int) int {
+	var sum int
+	slices.Sort(a)
+	n := len(a)
+	var cnt int
+	var arr []int
+	for i := 0; i < n; {
+		j := i
+		for i < n && a[i] == a[j] {
+			i++
+		}
+		sum += (i - j) / 2 * 2 * a[j]
+		cnt += (i - j) / 2 * 2
+		if (i-j)%2 == 1 {
+			arr = append(arr, a[j])
+		}
+	}
+
+	if cnt == 0 {
+		return 0
+	}
+
+	slices.Sort(arr)
+	slices.Reverse(arr)
+
+	for i := 0; i+1 < len(arr); i++ {
+		a, b := arr[i], arr[i+1]
+		if sum+b > a {
+			return sum + a + b
+		}
+
+	}
+
+	for i := 0; i < len(arr); i++ {
+		a := arr[i]
+		if sum > a {
+			return sum + a
+		}
+	}
+
+	if cnt == 2 {
+		return 0
+	}
+
+	return sum
+}

--- a/src/codeforces/set2/set21/set215/set2153/c/solution_test.go
+++ b/src/codeforces/set2/set21/set215/set2153/c/solution_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample %s, expect %d, but got %d", s, expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `3
+5 5 7`
+	expect := 17
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3
+5 5 10`
+	expect := 0
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `7
+4 3 5 1 5 3 3`
+	expect := 23
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set21/set215/set2153/d/problem.md
+++ b/src/codeforces/set2/set21/set215/set2153/d/problem.md
@@ -1,0 +1,74 @@
+# D. Not Alone (Codeforces 2153D)
+
+**Folder:** `solution.go` / `solution_test.go` — minimum operations to make a circular array “nice” under L1 cost; linear-time DP with three wrap alignments.
+
+**Statement (abridged):** A circular array `b` of length `n` is **nice** if every index `i` has at least one **adjacent** index (including `n` next to `1`) with the same value. Given integer circular array `a`, you may change entries by ±1 per operation. Minimize `Σ |b_i - a_i|`.
+
+Constraints: `3 ≤ n ≤ 2·10^5` per test, `Σ n ≤ 2·10^5`, `1 ≤ a_i ≤ 10^9`.
+
+---
+
+## Structure of nice arrays
+
+On a circle, indices with the same value form **contiguous arcs**. If some value appeared at a **single** index with different values on both sides, that index would have no equal neighbor — forbidden. So every maximal constant run has length **at least 2**.
+
+---
+
+## Key observation: only blocks of length 2 and 3
+
+In an optimal `b`, we can assume the circle is partitioned into blocks of lengths **2 or 3** only:
+
+- Any length `L ≥ 2` can be tiled by segments of size 2 and 3 (every integer `≥ 2` is a non-negative combination of 2 and 3).
+- **Cost of a block:** if positions `i..j` must all become one value `t`, the minimum `Σ |a_k - t|` over `t` is achieved at a **median** of the `a` values on that block.
+  - Length **2** `{x,y}`: optimal cost is `|x - y|` (any `t` between `x` and `y`).
+  - Length **3** `{x,y,z}`: optimal cost is `max(x,y,z) - min(x,y,z)` (median of three numbers).
+
+The implementation uses `calc` for these two cases (and handles `n = 2` or `n = 3` trivially).
+
+---
+
+## From circle to line: three “cut” alignments
+
+If we **cut** the circle between two indices, we get a line `0 .. n-1`. On the line, a valid partition uses only blocks of size 2 or 3 **unless** the cut falls **inside** a block that **wraps** around the end (that block uses a suffix of the line and a prefix).
+
+Such a wrapping block has length at most **3** (only sizes 2 and 3 are allowed). So the cut can lie:
+
+- **between** two blocks (`w = 1` in code — standard linear partition from the start), or
+- inside a **2-block** that straddles `(n-1, 0)`, or
+- inside a **3-block** that straddles the wrap.
+
+Trying **three** alignments (`play(1)`, `play(2)`, `play(3)` in `solution.go`) is enough: they correspond to reserving `w ∈ {1,2,3}` positions at the end of the index range so the DP state correctly accounts for the initial wrap block (see initial `dp` seeds for each `w`).
+
+---
+
+## DP on one alignment
+
+For a fixed `w`, let `dp[k]` be the minimum cost to cover indices `0..k` consistently with that alignment. The transition tries the last block length `d ∈ {2,3}` ending at the current position:
+
+```text
+dp[i+d-1] = min(dp[i+d-1], dp[i-1] + calc(a[i : i+d]))
+```
+
+(`calc` = pair or triple cost as above.)
+
+The loop runs for `i` from `1` up to `n - (w - 1) - 1` so that only feasible prefixes are updated; the answer for this alignment is `dp[n - w]`.
+
+**Initial states** differ per `w` so that the first one or two blocks match how the wrap-around block meets index `0`:
+
+- **`w == 1`:** no extra wrap in the seed — `dp[1] = |a[0]-a[1]|`, `dp[2] = calc(a[0:3])`.
+- **`w == 2`:** wrap uses `a[n-1]` with `a[0]` (pair) or extends to `a[1]` (triple); see `dp[0]`, `dp[1]`, `dp[2]` in code.
+- **`w == 3`:** wrap uses three indices around the seam `n-2, n-1, 0` or combinations with the start of the array; again encoded in `dp[0]`, `dp[1]`, `dp[2]`.
+
+The final answer is `min(play(1), play(2), play(3))`.
+
+---
+
+## Complexity
+
+`O(n)` time and `O(n)` memory per test case (constant number of DP passes).
+
+---
+
+## Reference
+
+[Problem 2153D on Codeforces](https://codeforces.com/problemset/problem/2153/D)

--- a/src/codeforces/set2/set21/set215/set2153/d/solution.go
+++ b/src/codeforces/set2/set21/set215/set2153/d/solution.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+const inf = 1 << 60
+
+func solve(a []int) int {
+	n := len(a)
+
+	if n == 2 {
+		return abs(a[0] - a[1])
+	}
+
+	calc := func(arr []int) int {
+		// len(arr) = 2 or 3
+		return slices.Max(arr) - slices.Min(arr)
+	}
+
+	if n == 3 {
+		return calc(a)
+	}
+	// 2个数，或者3个数一组，但是起点可以是n-2, n-1, 0
+
+	dp := make([]int, n)
+
+	play := func(w int) int {
+		for i := range n {
+			dp[i] = inf
+		}
+		switch w {
+		case 3:
+			dp[0] = calc([]int{a[n-2], a[n-1], a[0]})
+			dp[1] = abs(a[n-2]-a[n-1]) + abs(a[0]-a[1])
+			dp[2] = min(dp[0]+abs(a[1]-a[2]), abs(a[n-2]-a[n-1])+calc(a[:3]))
+		case 2:
+			dp[0] = abs(a[n-1] - a[0])
+			dp[1] = calc([]int{a[n-1], a[0], a[1]})
+			dp[2] = dp[0] + abs(a[1]-a[2])
+		default:
+			// w == 1
+			dp[1] = abs(a[0] - a[1])
+			dp[2] = calc(a[:3])
+		}
+
+		for i := 1; i < n-(w-1); i++ {
+			for d := 2; d <= 3 && i+d <= n-(w-1); d++ {
+				dp[i+d-1] = min(dp[i+d-1], dp[i-1]+calc(a[i:i+d]))
+			}
+		}
+		return dp[n-w]
+	}
+
+	return min(play(1), play(2), play(3))
+}
+
+func abs(num int) int {
+	if num < 0 {
+		return -num
+	}
+	return num
+}

--- a/src/codeforces/set2/set21/set215/set2153/d/solution_test.go
+++ b/src/codeforces/set2/set21/set215/set2153/d/solution_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample %s, expect %d, but got %d", s, expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `5
+1 1 1 1 1`
+	runSample(t, s, 0)
+}
+
+func TestSample2(t *testing.T) {
+	s := `4
+2 100 99 3`
+	runSample(t, s, 2)
+}
+
+func TestSample3(t *testing.T) {
+	s := `5
+2 2 5 9 5`
+	runSample(t, s, 4)
+}
+
+func TestSample4(t *testing.T) {
+	s := `6
+1 1 1 2 1 2`
+	runSample(t, s, 1)
+}
+
+func TestSample5(t *testing.T) {
+	s := `3
+248215438 248215438 785225899`
+	runSample(t, s, 537010461)
+}
+
+func TestSample6(t *testing.T) {
+	s := `3
+248215438 701092198 785225899`
+	runSample(t, s, 537010461)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3921/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3921/solution.go
@@ -1,0 +1,22 @@
+package p3921
+
+import "strconv"
+
+func scoreValidator(events []string) []int {
+	var score int
+	var count int
+	for _, cur := range events {
+		if cur == "W" {
+			count++
+		} else if cur == "WD" || cur == "NB" {
+			score++
+		} else {
+			v, _ := strconv.Atoi(cur)
+			score += v
+		}
+		if count == 10 {
+			break
+		}
+	}
+	return []int{score, count}
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3922/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3922/solution.go
@@ -1,0 +1,25 @@
+package p3922
+
+func minFlips(s string) int {
+	n := len(s)
+	if n < 3 {
+		return 0
+	}
+
+	cnt := make([]int, 2)
+
+	for _, x := range s {
+		cnt[int(x-'0')]++
+	}
+	res := min(cnt[0], cnt[1])
+
+	if cnt[1] > 0 {
+		// 只剩下一个1
+		res = min(res, cnt[1]-1)
+	}
+	if cnt[1] >= 2 && s[0] == '1' && s[n-1] == '1' {
+		res = min(res, cnt[1]-2)
+	}
+
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3923/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3923/solution.go
@@ -1,0 +1,51 @@
+package p3923
+
+import "slices"
+
+func minGenerations(points [][]int, target []int) int {
+	if slices.Max(target) > 6 {
+		return -1
+	}
+
+	var dim [7][7][7]int
+
+	for _, p := range points {
+		dim[p[0]][p[1]][p[2]]++
+	}
+
+	for k := 0; ; k++ {
+		var cur [][]int
+		for i := range 7 {
+			for j := range 7 {
+				for u := range 7 {
+					if dim[i][j][u] > 0 {
+						cur = append(cur, []int{i, j, u})
+						if i == target[0] && j == target[1] && u == target[2] {
+							return k
+						}
+					}
+				}
+			}
+		}
+
+		var add bool
+
+		for i := range cur {
+			for j := range i {
+				m0 := (cur[i][0] + cur[j][0]) / 2
+				m1 := (cur[i][1] + cur[j][1]) / 2
+				m2 := (cur[i][2] + cur[j][2]) / 2
+				if dim[m0][m1][m2] == 0 {
+					dim[m0][m1][m2]++
+					add = true
+				}
+			}
+		}
+
+		if !add {
+			break
+		}
+	}
+
+	return -1
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3923/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3923/solution_test.go
@@ -1,0 +1,17 @@
+package p3923
+
+import "testing"
+
+func runSample(t *testing.T, points [][]int, target []int, expect int) {
+	res := minGenerations(points, target)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	points := [][]int{{0, 0, 0}, {6, 6, 6}}
+	target := []int{3, 3, 3}
+	expect := 1
+	runSample(t, points, target, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3924/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3924/solution.go
@@ -1,0 +1,71 @@
+package p3924
+
+import (
+	"math"
+	"sort"
+)
+
+func minimumThreshold(n int, edges [][]int, source int, target int, k int) int {
+	type edge struct{ to, wt int }
+	g := make([][]edge, n)
+	maxWt := 0
+	for _, e := range edges {
+		x, y, wt := e[0], e[1], e[2]
+		g[x] = append(g[x], edge{y, wt})
+		g[y] = append(g[y], edge{x, wt})
+		maxWt = max(maxWt, wt)
+	}
+
+	dis := make([]int, n)
+	ans := sort.Search(maxWt+1, func(threshold int) bool {
+		for i := range dis {
+			dis[i] = math.MaxInt
+		}
+		dis[source] = 0
+
+		type pair struct{ x, d int }
+		ql, qr := []pair{{source, dis[source]}}, []pair{} // 模拟双端队列
+
+		for len(ql) > 0 || len(qr) > 0 {
+			var p pair
+			if len(ql) > 0 {
+				ql, p = ql[:len(ql)-1], ql[len(ql)-1] // 队首出
+			} else {
+				p, qr = qr[0], qr[1:] // 队尾出
+			}
+
+			x := p.x
+			if x == target {
+				return true
+			}
+
+			if p.d > dis[x] {
+				continue
+			}
+
+			for _, e := range g[x] {
+				y := e.to
+				wt := 0
+				if e.wt > threshold {
+					wt = 1
+				}
+				newDis := p.d + wt
+				if newDis < dis[y] {
+					dis[y] = newDis
+					if wt == 0 {
+						ql = append(ql, pair{y, newDis}) // 加到队首
+					} else if newDis <= k {
+						qr = append(qr, pair{y, newDis}) // 加到队尾
+					}
+				}
+			}
+		}
+
+		return false
+	})
+
+	if ans > maxWt { // 图不连通
+		return -1
+	}
+	return ans
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3924/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3924/solution_test.go
@@ -1,0 +1,61 @@
+package p3924
+
+import "testing"
+
+func runSample(t *testing.T, n int, edges [][]int, source int, target int, k int, expect int) {
+	res := minimumThreshold(n, edges, source, target, k)
+
+	if res != expect {
+		t.Fatalf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	n := 6
+	edges := [][]int{{0, 1, 5}, {1, 2, 3}, {3, 4, 4}, {4, 5, 1}, {1, 4, 2}}
+	source := 0
+	target := 3
+	k := 1
+	expect := 4
+	runSample(t, n, edges, source, target, k, expect)
+}
+
+func TestSample2(t *testing.T) {
+	n := 6
+	edges := [][]int{{0, 1, 3}, {1, 2, 4}, {3, 4, 5}, {4, 5, 6}}
+	source := 0
+	target := 4
+	k := 1
+	expect := -1
+	runSample(t, n, edges, source, target, k, expect)
+}
+
+func TestSample3(t *testing.T) {
+	n := 4
+	edges := [][]int{{0, 1, 2}, {1, 2, 2}, {2, 3, 2}, {3, 0, 2}}
+	source := 0
+	target := 0
+	k := 0
+	expect := 0
+	runSample(t, n, edges, source, target, k, expect)
+}
+
+func TestSample4(t *testing.T) {
+	n := 4
+	edges := [][]int{{2, 3, 18}, {1, 2, 96}}
+	source := 1
+	target := 2
+	k := 2
+	expect := 0
+	runSample(t, n, edges, source, target, k, expect)
+}
+
+func TestSample5(t *testing.T) {
+	n := 3
+	edges := [][]int{{1, 2, 77}, {0, 2, 36}}
+	source := 1
+	target := 1
+	k := 1
+	expect := 0
+	runSample(t, n, edges, source, target, k, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3925/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3925/solution.go
@@ -1,0 +1,13 @@
+package p3925
+
+import "slices"
+
+
+func concatWithReverse(nums []int) []int {
+	n := len(nums)
+	res := make([]int, 2 * n)
+	copy(res, nums)
+	slices.Reverse(nums)
+	copy(res[n:], nums)
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3926/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3926/solution.go
@@ -1,0 +1,56 @@
+package p3926
+
+import "bytes"
+
+func countWordOccurrences(chunks []string, queries []string) []int {
+	freq := make(map[string]int)
+
+	var buf bytes.Buffer
+	var last byte = ' '
+
+	checkAppendable := func(x byte) bool {
+		if x >= 'a' && x <= 'z' {
+			return true
+		}
+		if x == '-' && (buf.Len() > 0 && last >= 'a' && last <= 'z') {
+			return true
+		}
+		return false
+	}
+
+	add := func() {
+		x := buf.String()
+		// not appendable
+		if last == '-' {
+			x = x[:len(x)-1]
+		}
+		if len(x) > 0 {
+			freq[x]++
+		}
+		buf.Reset()
+		last = ' '
+	}
+
+	for _, chunk := range chunks {
+		for i := 0; i < len(chunk); i++ {
+			if checkAppendable(chunk[i]) {
+				buf.WriteByte(chunk[i])
+				last = chunk[i]
+				continue
+			}
+			if buf.Len() > 0 {
+				add()
+			}
+		}
+	}
+
+	if buf.Len() > 0 {
+		add()
+	}
+
+	res := make([]int, len(queries))
+	for i, query := range queries {
+		res[i] = freq[query]
+	}
+	return res
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3926/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3926/solution_test.go
@@ -1,0 +1,34 @@
+package p3926
+
+import (
+	"reflect"
+	"testing"
+)
+
+func runSample(t *testing.T, chunks []string, queries []string, expect []int) {
+	res := countWordOccurrences(chunks, queries)
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	chunks := []string{"hello wor", "ld hello"}
+	queries := []string{"hello", "world", "wor"}
+	expect := []int{2, 1, 0}
+	runSample(t, chunks, queries, expect)
+}
+
+func TestSample2(t *testing.T) {
+	chunks := []string{"a--b a-", "-c"}
+	queries := []string{"a", "b", "c"}
+	expect := []int{2, 1, 1}
+	runSample(t, chunks, queries, expect)
+}
+
+func TestSample3(t *testing.T) {
+	chunks := []string{"hello"}
+	queries := []string{"hello", "ell"}
+	expect := []int{1, 0}
+	runSample(t, chunks, queries, expect)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3927/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3927/solution.go
@@ -1,0 +1,31 @@
+package p3927
+
+import "slices"
+
+func minArraySum(nums []int) int64 {
+	x := slices.Max(nums)
+	freq := make([]int, x+1)
+	for _, v := range nums {
+		freq[v]++
+	}
+	n := len(nums)
+	if freq[1] > 0 {
+		return int64(n)
+	}
+	var res int
+	marked := make([]bool, x+1)
+	for i := 2; i <= x; i++ {
+		if marked[i] || freq[i] == 0 {
+			continue
+		}
+		var cnt int
+		for j := i; j <= x; j += i {
+			if !marked[j] {
+				cnt += freq[j]
+			}
+			marked[j] = true
+		}
+		res += cnt * i
+	}
+	return int64(res)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3928/solution.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3928/solution.go
@@ -1,0 +1,137 @@
+package p3928
+
+import (
+	"container/heap"
+)
+
+const inf = 1 << 60
+
+func minCost(n int, prices []int, roads [][]int) []int {
+	adj := make([][]int, n)
+	for i, e := range roads {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], i)
+		adj[v] = append(adj[v], i)
+	}
+
+	nodes := make([]*node, n)
+	for i := range n {
+		nodes[i] = &node{i, inf, i}
+	}
+
+	dijkstra := func(start int) []int {
+		pq := make(PriorityQueue, n)
+		for i := range n {
+			nodes[i].priority = inf
+			pq[i] = nodes[i]
+			pq[i].index = i
+		}
+
+		heap.Init(&pq)
+		pq.update(nodes[start], 0)
+
+		for pq.Len() > 0 {
+			cur := heap.Pop(&pq).(*node)
+			u := cur.id
+			w := cur.priority
+			for _, i := range adj[u] {
+				v := roads[i][0] ^ roads[i][1] ^ u
+				cost := roads[i][2]
+				tax := roads[i][3]
+				if nodes[v].priority > w+cost*tax {
+					pq.update(nodes[v], w+cost*tax)
+				}
+			}
+		}
+		dist := make([]int, n)
+		for i := range n {
+			dist[i] = nodes[i].priority
+		}
+		return dist
+	}
+
+	dists := make([][]int, n)
+	for i := range n {
+		dists[i] = dijkstra(i)
+	}
+
+	play := func(s int) int {
+		pq := make(PriorityQueue, n)
+		for i := range n {
+			nodes[i].priority = inf
+			pq[i] = nodes[i]
+			pq[i].index = i
+		}
+		heap.Init(&pq)
+		pq.update(nodes[s], 0)
+		for pq.Len() > 0 {
+			cur := heap.Pop(&pq).(*node)
+			u := cur.id
+			w := cur.priority
+			for _, i := range adj[u] {
+				v := roads[i][0] ^ roads[i][1] ^ u
+				nw := w + roads[i][2]
+				if nw < nodes[v].priority {
+					pq.update(nodes[v], nw)
+				}
+			}
+		}
+
+		ans := prices[s]
+
+		for i := range n {
+			ans = min(ans, prices[i]+nodes[i].priority+dists[i][s])
+		}
+
+		return ans
+	}
+
+	res := make([]int, n)
+	for i := range n {
+		res[i] = play(i)
+	}
+	return res
+}
+
+type node struct {
+	id       int
+	priority int
+	index    int
+}
+
+type PriorityQueue []*node
+
+func (pq PriorityQueue) Len() int {
+	return len(pq)
+}
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	return pq[i].priority < pq[j].priority
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *PriorityQueue) Push(x any) {
+	item := x.(*node)
+	item.index = len(*pq)
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq *PriorityQueue) update(item *node, priority int) {
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}

--- a/src/leetcode/set1000/set3000/set3900/set3920/p3928/solution_test.go
+++ b/src/leetcode/set1000/set3000/set3900/set3920/p3928/solution_test.go
@@ -1,0 +1,37 @@
+package p3928
+
+import (
+	"reflect"
+	"testing"
+)
+
+func runSample(t *testing.T, n int, prices []int, roads [][]int, expect []int) {
+	res := minCost(n, prices, roads)
+	if !reflect.DeepEqual(res, expect) {
+		t.Errorf("Sample expect %v, but got %v", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	n := 2
+	prices := []int{8, 3}
+	roads := [][]int{{0, 1, 1, 2}}
+	expect := []int{6, 3}
+	runSample(t, n, prices, roads, expect)
+}
+
+func TestSample2(t *testing.T) {
+	n := 3
+	prices := []int{9, 4, 6}
+	roads := [][]int{{0, 1, 1, 3}, {1, 2, 4, 2}}
+	expect := []int{8, 4, 6}
+	runSample(t, n, prices, roads, expect)
+}
+
+func TestSample3(t *testing.T) {
+	n := 3
+	prices := []int{10, 11, 1}
+	roads := [][]int{{0, 2, 1, 3}, {1, 2, 3, 4}, {0, 1, 5, 2}}
+	expect := []int{5, 11, 1}
+	runSample(t, n, prices, roads, expect)
+}


### PR DESCRIPTION
## Summary
- Add LeetCode solutions (and tests where present) for problems 3921 through 3928 under `set3920`.
- Add Codeforces 2153 C/D solutions; extend 2153D `problem.md` with a detailed write-up.

## Test plan
- [ ] `go test ./src/codeforces/set2/set21/set215/set2153/c/`
- [ ] `go test ./src/codeforces/set2/set21/set215/set2153/d/`
- [ ] `go test ./src/leetcode/set1000/set3000/set3900/set3920/p3923/`
- [ ] `go test ./src/leetcode/set1000/set3000/set3900/set3920/p3924/`
- [ ] `go test ./src/leetcode/set1000/set3000/set3900/set3920/p3926/`
- [ ] `go test ./src/leetcode/set1000/set3000/set3900/set3920/p3928/`

Made with [Cursor](https://cursor.com)