### PR TITLE
Add Codeforces 57D, 121D, 1965A, 2203C, 2207 B/D

### DIFF
--- a/src/codeforces/set0/set0/set050/set057/d/problem.md
+++ b/src/codeforces/set0/set0/set050/set057/d/problem.md
@@ -1,0 +1,75 @@
+# D. Average lifespan (Codeforces 57D)
+
+Stewie the Rabbit explores a new parallel universe shaped as a rectangular grid with `n` rows and `m` columns. The universe is small: each cell holds **at most one** particle.
+
+Each particle is either **static** or **dynamic**.
+
+- **Static** particles never move. No two static particles share a **row** or a **column**, and none occupy **diagonally adjacent** cells.
+- A **dynamic** particle appears in a **uniformly random empty** cell, then chooses a **uniformly random empty** cell as its destination (the destination may equal the start). It moves along a **shortest path** through cells not occupied by static particles. When it reaches the destination, it disappears. Only one dynamic particle exists at a time.
+
+The particle may move between **edge-adjacent** cells; each such step takes **one galactic second**.
+
+Find the **expected** (average) lifespan of one such particle.
+
+## Input
+
+The first line contains two integers `n` and `m` (`2 <= n, m <= 1000`) — grid dimensions.
+
+The next `n` lines each contain `m` characters:
+
+- `'X'` — static particle in that cell  
+- `'.'` — empty cell  
+
+The grid is guaranteed to satisfy the static-particle rules above.
+
+## Output
+
+Print a single real number — the average lifespan, with **at least 6** decimal digits shown.
+
+The answer is accepted if the absolute or relative error is at most `10^-6`.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```text
+2 2
+..
+.X
+```
+
+**Output**
+
+```text
+0.888888888889
+```
+
+### Example 2
+
+**Input**
+
+```text
+3 3
+...
+.X.
+...
+```
+
+**Output**
+
+```text
+2.000000000000
+```
+
+Original: [Codeforces 57D](https://codeforces.com/problemset/problem/57/D)
+
+
+### ideas
+1. 固定起点(r1, c1), 计算所有其他节点到它的最少距离的和，除以(free - 1)
+2. 加起来，最后再除以 free?
+3. 但是这样的复杂性 = n * m * n * m too much
+4. 所以要利用没有同一行，用一列有X的性质
+5. 如果在某一行里面没有X，那么这一行的贡献很容易计算（同列同理）
+6. 如果有一个X，那么+2？因为，没有相邻的斜向的X

--- a/src/codeforces/set0/set0/set050/set057/d/solution.go
+++ b/src/codeforces/set0/set0/set050/set057/d/solution.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%.12f\n", drive(reader))
+}
+
+func drive(reader *bufio.Reader) float64 {
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	universe := make([]string, n)
+	for i := range n {
+		fmt.Fscan(reader, &universe[i])
+	}
+	return solve(universe)
+}
+
+func solve(universe []string) float64 {
+	n := len(universe)
+	m := len(universe[0])
+
+	row := make([]int64, n)
+	col := make([]int64, m)
+	var free int64
+
+	for i := range n {
+		for j := range m {
+			if universe[i][j] != 'X' {
+				row[i]++
+				col[j]++
+				free++
+			}
+		}
+	}
+
+	var tot int64
+
+	var cnt, sum int64
+	for i := range n {
+		tot += int64(i)*cnt*row[i] - sum*row[i]
+		cnt += row[i]
+		sum += int64(i) * row[i]
+	}
+
+	cnt, sum = 0, 0
+	for j := range m {
+		tot += int64(j)*cnt*col[j] - sum*col[j]
+		cnt += col[j]
+		sum += int64(j) * col[j]
+	}
+
+	for i := range n {
+		var left int64
+		for j := range m {
+			if universe[i][j] == 'X' {
+				tot += 2 * left * (row[i] - left)
+			} else {
+				left++
+			}
+		}
+	}
+
+	for j := range m {
+		var up int64
+		for i := range n {
+			if universe[i][j] == 'X' {
+				tot += 2 * up * (col[j] - up)
+			} else {
+				up++
+			}
+		}
+	}
+
+	return float64(tot*2) / float64(free*free)
+}

--- a/src/codeforces/set0/set0/set050/set057/d/solution_test.go
+++ b/src/codeforces/set0/set0/set050/set057/d/solution_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"math"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect float64) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if math.Abs(res-expect) > 1e-6 {
+		t.Errorf("Sample expect %f, but got %f", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `2 2
+..
+.X
+`
+	runSample(t, s, 0.888888888889)
+}
+
+func TestSample2(t *testing.T) {
+	s := `3 3
+...
+.X.
+...
+`
+	runSample(t, s, 2.0)
+}

--- a/src/codeforces/set0/set1/set120/set121/d/problem.md
+++ b/src/codeforces/set0/set1/set120/set121/d/problem.md
@@ -1,0 +1,215 @@
+# D. Lucky Segments (Codeforces 121D)
+
+**Limits:** 4 seconds per test, 256 MB  
+**I/O:** standard input / standard output
+
+Source: [https://codeforces.com/problemset/problem/121/D](https://codeforces.com/problemset/problem/121/D)
+
+---
+
+**Lucky numbers** are positive integers whose decimal representation contains only the digits **4** and **7**. For example, `47`, `744`, and `4` are lucky; `5`, `17`, and `467` are not.
+
+Petya has `n` **closed segments** `[l_1; r_1], [l_2; r_2], …, [l_n; r_n]`.
+
+In **one move**, he may pick any segment `i` and replace it with either:
+
+- `[l_i + 1; r_i + 1]`, or  
+- `[l_i - 1; r_i - 1]`
+
+(i.e. shift that segment left or right by **1**).
+
+A number `x` is called **full** if it lies in **every** segment: for all `i` (`1 ≤ i ≤ n`), `l_i ≤ x ≤ r_i`.
+
+Petya makes **at most `k` moves**. After that, he counts how many **full lucky numbers** exist. Find the **maximum** possible count.
+
+## Input
+
+The first line contains two integers `n` and `k` (`1 ≤ n ≤ 10^5`, `1 ≤ k ≤ 10^18`) — the number of segments and the move budget.
+
+Each of the next `n` lines contains two integers `l_i` and `r_i` (`1 ≤ l_i ≤ r_i ≤ 10^18`).
+
+*(Statement note: in C++, avoid `%lld` for 64-bit I/O; `%I64d` is mentioned on the original page.)*
+
+## Output
+
+Print a single integer — the answer.
+
+## Examples
+
+### Example 1
+
+**Input**
+
+```text
+4 7
+1 4
+6 9
+4 7
+3 5
+```
+
+**Output**
+
+```text
+1
+```
+
+### Example 2
+
+**Input**
+
+```text
+2 7
+40 45
+47 74
+```
+
+**Output**
+
+```text
+2
+```
+
+## Note
+
+In the first sample, shifting the second segment two units left gives `[4; 7]`, after which `4` is full.
+
+In the second sample, shift the first segment two units right to `[42; 47]` and the second segment three units left to `[44; 71]`; then `44` and `47` are full.
+
+
+## Solution
+
+After all moves, every segment is still a segment with the same length as before.  If the final common intersection contains some interval `[L, R]`, then every original segment `[l_i, r_i]` must be shifted so that it covers `[L, R]`.
+
+For one segment:
+
+- if `l_i > L`, its left endpoint must move left to at most `L`, costing at least `l_i - L`;
+- if `r_i < R`, its right endpoint must move right to at least `R`, costing at least `R - r_i`;
+- if `l_i <= L` and `r_i >= R`, it already covers `[L, R]`, costing `0`.
+
+So the minimum cost to make all segments cover `[L, R]` is:
+
+```text
+sum(max(0, l_i - L)) + sum(max(0, R - r_i))
+```
+
+This formula is exact. Moving a segment left helps only with the left boundary, and moving it right helps only with the right boundary. If a segment is too far right (`l_i > L`), moving it left by `l_i - L` is enough for the left boundary; because we only test intervals whose length is no larger than the minimum segment length, this shifted segment can also cover the right boundary. The symmetric argument applies when `r_i < R`.
+
+Therefore an interval `[L, R]` is feasible iff:
+
+1. `R - L + 1 <= minLen`, where `minLen = min(r_i - l_i + 1)`;
+2. the cost above is at most `k`.
+
+### Which Intervals Need Checking?
+
+We only care about lucky numbers inside the final intersection. Suppose we want at least `w` full lucky numbers. Then it is enough to choose `w` consecutive lucky numbers:
+
+```text
+lucky[i], lucky[i+1], ..., lucky[i+w-1]
+```
+
+and ask whether all of them can be covered. The tightest interval that contains them is:
+
+```text
+L = lucky[i]
+R = lucky[i+w-1]
+```
+
+If this tight interval is feasible, then those `w` lucky numbers are full. If it is not feasible, any larger interval containing the same lucky numbers is no easier to cover, because it only makes the boundary requirements stricter. So checking all consecutive lucky-number windows is sufficient.
+
+The answer is monotonic: if `w` lucky numbers can be made full, then any smaller number can also be made full. Thus we binary search `w`.
+
+### Lucky Number Range
+
+The lucky numbers must be generated beyond the original maximum right endpoint.
+
+Let:
+
+```text
+maxR = max(r_i)
+```
+
+No final full number can be greater than `maxR + k`, because even the segment with the largest original right endpoint would need more than `k` right moves to reach such a number. On the other hand, lucky numbers greater than `maxR` can be useful, because the whole intersection may be shifted right using the move budget.
+
+So the correct generation limit is:
+
+```text
+maxR + k
+```
+
+not just `maxR`.
+
+### Fast Cost Calculation
+
+For a fixed left boundary `L`, the first cost part is:
+
+```text
+sum(max(0, l_i - L))
+= sum(l_i - L for all l_i >= L)
+= sum(l_i for all l_i >= L) - count(l_i >= L) * L
+```
+
+Sort segments by `l_i`. For every lucky number `L`, precompute:
+
+```text
+dp[L].sum = sum of l_i where l_i >= L
+dp[L].cnt = count of such l_i
+```
+
+Then:
+
+```text
+leftCost = dp[L].sum - dp[L].cnt * L
+```
+
+Similarly, for a fixed right boundary `R`:
+
+```text
+sum(max(0, R - r_i))
+= sum(R - r_i for all r_i <= R)
+= count(r_i <= R) * R - sum(r_i for all r_i <= R)
+```
+
+Sort segments by `r_i`. For every lucky number `R`, precompute:
+
+```text
+fp[R].sum = sum of r_i where r_i <= R
+fp[R].cnt = count of such r_i
+```
+
+Then:
+
+```text
+rightCost = fp[R].cnt * R - fp[R].sum
+```
+
+For a lucky window `[lucky[i], lucky[j]]`, the total cost is:
+
+```text
+leftCost + rightCost
+```
+
+If the interval length is at most `minLen` and this cost is at most `k`, then this window is feasible.
+
+### Overflow Detail
+
+Although `k`, `l_i`, and `r_i` fit in 64-bit integers, sums such as:
+
+```text
+sum(l_i)
+sum(r_i)
+```
+
+can be as large as `10^5 * 10^18 = 10^23`, which does not fit in signed 64-bit integers. The implementation stores these prefix/suffix sums in a small unsigned 128-bit helper built from two `uint64` values. We only need addition, subtraction, multiplication of two ordinary `int` values, and comparison with `k`.
+
+### Complexity
+
+The number of lucky numbers up to about `2 * 10^18` is below `2^20`. Let this count be `m`.
+
+```text
+Generate lucky numbers: O(m)
+Sort segments:          O(n log n)
+Build dp/fp arrays:     O(n + m)
+Binary search answer:   O(m log m)
+Memory:                 O(m)
+```

--- a/src/codeforces/set0/set1/set120/set121/d/solution.go
+++ b/src/codeforces/set0/set1/set120/set121/d/solution.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"cmp"
+	"fmt"
+	"math/bits"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println(drive(reader))
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	segs := make([][]int, n)
+	for i := range n {
+		segs[i] = make([]int, 2)
+		fmt.Fscan(reader, &segs[i][0], &segs[i][1])
+	}
+	return solve(n, k, segs)
+}
+
+const inf = 1 << 60
+
+type uint128 struct {
+	hi uint64
+	lo uint64
+}
+
+func (a uint128) add(b uint128) uint128 {
+	lo, carry := bits.Add64(a.lo, b.lo, 0)
+	hi, _ := bits.Add64(a.hi, b.hi, carry)
+	return uint128{hi, lo}
+}
+
+func (a uint128) sub(b uint128) uint128 {
+	lo, borrow := bits.Sub64(a.lo, b.lo, 0)
+	hi, _ := bits.Sub64(a.hi, b.hi, borrow)
+	return uint128{hi, lo}
+}
+
+func fromInt(x int) uint128 {
+	return uint128{0, uint64(x)}
+}
+
+func mulInt(a int, b int) uint128 {
+	hi, lo := bits.Mul64(uint64(a), uint64(b))
+	return uint128{hi, lo}
+}
+
+func (a uint128) leInt(b int) bool {
+	return a.hi == 0 && a.lo <= uint64(b)
+}
+
+type stat struct {
+	sum uint128
+	cnt int
+}
+
+func solve(n int, k int, segs [][]int) int {
+	var limit int
+	wn := inf
+	for _, cur := range segs {
+		limit = max(limit, cur[1])
+		wn = min(wn, cur[1]-cur[0]+1)
+	}
+	limit += k
+
+	var lucky []int
+
+	var gen func(x int)
+	gen = func(x int) {
+		if x > 0 {
+			lucky = append(lucky, x)
+		}
+		if limit >= 4 && x <= (limit-4)/10 {
+			gen(x*10 + 4)
+		}
+		if limit >= 7 && x <= (limit-7)/10 {
+			gen(x*10 + 7)
+		}
+	}
+
+	gen(0)
+
+	slices.Sort(lucky)
+
+	slices.SortFunc(segs, func(a, b []int) int {
+		return cmp.Or(a[0]-b[0], a[1]-b[1])
+	})
+
+	m := len(lucky)
+	// dp[i]表示在luck[i]的后面有多少x[?] >= lucky[i]
+	dp := make([]stat, m+1)
+	for i, j := m-1, n-1; i >= 0; i-- {
+		dp[i] = dp[i+1]
+		for j >= 0 && segs[j][0] >= lucky[i] {
+			dp[i].sum = dp[i].sum.add(fromInt(segs[j][0]))
+			dp[i].cnt++
+			j--
+		}
+	}
+
+	slices.SortFunc(segs, func(a, b []int) int {
+		return cmp.Or(a[1]-b[1], a[0]-b[0])
+	})
+
+	fp := make([]stat, m+1)
+
+	for i, j := 0, 0; i < m; i++ {
+		fp[i+1] = fp[i]
+		for j < n && segs[j][1] <= lucky[i] {
+			fp[i+1].sum = fp[i+1].sum.add(fromInt(segs[j][1]))
+			fp[i+1].cnt++
+			j++
+		}
+	}
+
+	check := func(w int) bool {
+		if w == 0 {
+			return true
+		}
+
+		for i := 0; i+w <= m; i++ {
+			j := i + w - 1
+			if lucky[j]-lucky[i]+1 <= wn {
+				// 但是有一个比较麻烦，就是那些刚好落在 [luck[i], luck[j]]两端的，这些是不用移动的
+				s1 := dp[i].sum.sub(mulInt(dp[i].cnt, lucky[i]))
+				s2 := mulInt(fp[j+1].cnt, lucky[j]).sub(fp[j+1].sum)
+				if s1.add(s2).leInt(k) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	l, r := 0, m+1
+	for l < r {
+		mid := (l + r) / 2
+		if check(mid) {
+			l = mid + 1
+		} else {
+			r = mid
+		}
+	}
+	return r - 1
+}

--- a/src/codeforces/set0/set1/set120/set121/d/solution_test.go
+++ b/src/codeforces/set0/set1/set120/set121/d/solution_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runDrive(t *testing.T, input string, expect int) {
+	t.Helper()
+	r := bufio.NewReader(strings.NewReader(input))
+	res := drive(r)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	input := `4 7
+1 4
+6 9
+4 7
+3 5
+`
+	expect := 1
+	runDrive(t, input, expect)
+}
+
+func TestSample2(t *testing.T) {
+	input := `2 7
+40 45
+47 74
+`
+	expect := 2
+	runDrive(t, input, expect)
+}
+
+func TestSample3(t *testing.T) {
+	input := `74 77
+22 23
+21 23
+11 20
+15 19
+22 26
+26 27
+10 14
+18 23
+22 22
+16 18
+3 23
+6 6
+2 22
+13 24
+13 24
+8 12
+25 26
+3 26
+5 17
+7 7
+8 21
+2 6
+19 22
+6 16
+2 27
+10 18
+15 16
+10 12
+26 27
+9 12
+5 5
+21 22
+24 27
+26 26
+12 16
+26 27
+1 6
+17 18
+8 14
+4 11
+26 27
+5 14
+25 25
+13 17
+22 27
+5 9
+19 21
+8 15
+19 19
+6 8
+11 22
+8 12
+11 15
+10 24
+22 24
+8 10
+25 27
+7 7
+7 13
+15 17
+24 25
+26 26
+27 27
+26 27
+25 26
+2 4
+19 25
+4 8
+25 27
+19 23
+16 27
+15 21
+14 19
+2 15
+`
+	expect := 0
+	runDrive(t, input, expect)
+}
+
+func TestShiftBeyondOriginalRightEndpoint(t *testing.T) {
+	input := `1 43
+1 31
+`
+	expect := 3
+	runDrive(t, input, expect)
+}
+
+func TestLargeCostDoesNotOverflow(t *testing.T) {
+	input := `10 0
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+1000000000000000000 1000000000000000000
+`
+	expect := 0
+	runDrive(t, input, expect)
+}

--- a/src/codeforces/set1/set19/set196/set1965/a/problem.md
+++ b/src/codeforces/set1/set19/set196/set1965/a/problem.md
@@ -1,0 +1,118 @@
+# A. Stone piles (Codeforces 1965A)
+
+Alice and Bob play a game on `n` piles of stones. On each turn, the current player chooses a positive integer `k` that is **at most** the size of the **smallest nonempty pile**, then removes `k` stones from **every** nonempty pile at once. The first player who cannot move (all piles empty) **loses**.
+
+Alice moves first. If both play optimally, who wins?
+
+## Input
+
+The first line contains a single integer `t` (`1 <= t <= 10^4`) — the number of test cases.
+
+For each test case:
+
+- The first line contains an integer `n` (`1 <= n <= 2 * 10^5`) — the number of piles.
+- The second line contains `n` integers `a_1, a_2, ..., a_n` (`1 <= a_i <= 10^9`) — initial pile sizes.
+
+It is guaranteed that the sum of `n` over all test cases does not exceed `2 * 10^5`.
+
+## Output
+
+For each test case, print one line with the winner's name: `Alice` if Alice wins, otherwise `Bob` (no quotes).
+
+## Example
+
+### Input
+
+```text
+7
+5
+3 3 3 3 3
+2
+1 7
+7
+1 3 9 7 4 2 100
+3
+1 2 3
+6
+2 1 3 4 2 4
+8
+5 7 2 9 6 3 3 2
+1
+1000000000
+```
+
+### Output
+
+```text
+Alice
+Bob
+Alice
+Alice
+Bob
+Alice
+Alice
+```
+
+## Note
+
+In the first test case, Alice can choose `k = 3` on her first turn and empty all piles at once.
+
+In the second test case, Alice must choose `k = 1` on her first turn because one pile has size `1`. Bob can then choose `k = 6` on his turn and win.
+
+Original: [Codeforces 1965A](https://codeforces.com/problemset/problem/1965/A)
+
+## Solution summary (from `solution.go`)
+
+**Reduce the position**
+
+- Sort `a` and **remove duplicates** with `slices.Compact`. Only the **sorted distinct heights** matter: duplicate counts do not change who wins under these rules.
+
+**One distinct height**
+
+- If there is a single value after compaction, Alice empties everything in one move (`k` = that height). Return **Alice**.
+
+**Several distinct heights**
+
+- Let the sorted distinct sizes be `b[0] < b[1] < ... < b[m-1]`.
+- Simulate the game along these levels. Maintain `w ∈ {0,1}` meaning whose “turn” it is in this abstraction (`0` → Alice, `1` → Bob), matching `players := []string{Alice, Bob}` in code.
+
+**Gap along consecutive levels**
+
+For each index `i` from `0` to `m-2` (the loop handles the last index separately):
+
+- `diff = b[i]` when `i == 0`, else `diff = b[i] - b[i-1]` — how many stones are removed from the smallest nonempty pile when the configuration advances from one distinct level to the next.
+
+- If **`diff > 1`**: the current player `players[w]` can choose `k` so the game does not stay tight on the next step; they **win immediately**. Return `players[w]`.
+
+- If **`diff == 1`**: the move is forced in this model; control passes to the opponent, so **`w ^= 1`**.
+
+**Last level**
+
+- When `i == m-1`, the current player can take all remaining stones in one move. Return **`players[w]`**.
+
+### Why this is correct (proof)
+
+**Lemma 1 (duplicates and order).**  
+Every turn applies the same `k` to every nonempty pile, so two piles that are ever equal stay equal until both hit `0`. Hence only **sorted distinct** pile sizes matter; duplicates can be merged and pile order ignored.
+
+**Lemma 2 (gap decomposition).**  
+Let `b[0] < … < b[m-1]` be those distinct sizes. For `i ≥ 1`, write `g_i = b[i] - b[i-1]`, and set `g_0 = b[0]` (the code’s `diff` at index `i` equals `g_i`). Intuitively, `g_i` is how much “height” separates two consecutive layers of stones once everything below `b[i-1]` has already been removed.
+
+**Lemma 3 (first gap `g_0 = b[0]`).**  
+If `g_0 ≥ 2` (equivalently `b[0] > 1`), Alice wins. One explicit first move is `k = b[0] - 1`: every pile that started at `b[0]` becomes `1`, and every pile that started strictly larger becomes at least `(b[1] - (b[0] - 1))` when `m ≥ 2`, hence at least `2` when the next gap `g_1 = b[1] - b[0]` is `1`, and at least `3` when `g_1 ≥ 2`. In particular the new global minimum is `1`, so Bob’s next move must use `k = 1`. From there, a finite case analysis on how many piles sit at the current minimum versus the next height shows Alice can force a win whenever the bottom layer started with size `≥ 2` (this is the content of the official editorial for 1965A; the code’s `diff > 1` at `i = 0` is exactly this condition).
+
+**Lemma 4 (a later gap `g_i ≥ 2`).**  
+After any number of tight steps with `g = 1`, the residual game is the same rule on the remaining distinct heights, shifted down so that the “new bottom” is the old `b[i-1]` layer. If the next gap `b[i] - b[i-1] ≥ 2`, the **current** player to move in that residual game is exactly `players[w]` in the implementation, and the same slack phenomenon as Lemma 3 applies at this two-tier interface, so that player wins immediately — hence the early return on `diff > 1` for `i > 0` as well.
+
+**Lemma 5 (tight gaps `g_i = 1`).**  
+If `g_i = 1`, there is no extra slack between the two consecutive distinct heights: every legal move that reduces the smallest positive tier forces the next decision to be made by the **opponent** in the compressed game on the remaining larger piles. That is exactly the `w ^= 1` update.
+
+**Lemma 6 (only the maximum remains).**  
+When the scan reaches the last distinct height, all nonempty piles are equal; whoever moves takes all stones in one turn and wins, so returning `players[w]` is correct.
+
+Lemmas 1–6 justify the loop in `solve` (full step-by-step game induction is the same as in the contest editorial; the lemmas above isolate the invariants the code encodes).
+
+**Complexity**
+
+- Sorting dominates: `O(n log n)` time and `O(n)` extra space per test case (compaction is in-place on the sorted slice).
+

--- a/src/codeforces/set1/set19/set196/set1965/a/solution.go
+++ b/src/codeforces/set1/set19/set196/set1965/a/solution.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) string {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(a)
+}
+
+const Alice = "Alice"
+const Bob = "Bob"
+
+func solve(a []int) string {
+	slices.Sort(a)
+	a = slices.Compact(a)
+
+	if len(a) == 1 {
+		return Alice
+	}
+
+	// 第一个遇到差值超过1的
+	players := []string{Alice, Bob}
+	var w int
+	for i := 0; i < len(a); i++ {
+		if i == len(a)-1 {
+			// 当前用户可以全部取走
+			return players[w]
+		}
+		// 如果diff = 1， 那么当前player没有选择，只能把主动权给对方
+		// 但是diff > 1的时候，如果从下一个状态开始，第一个move的player会输掉，那么就let m = diff
+		// 否则的话，只要选择 diff - 1, 就可以扭转战局
+		diff := a[i]
+		if i > 0 {
+			diff -= a[i-1]
+		}
+		if diff > 1 {
+			return players[w]
+		}
+		w ^= 1
+	}
+	// not reachable
+	return Alice
+}

--- a/src/codeforces/set1/set19/set196/set1965/a/solution_test.go
+++ b/src/codeforces/set1/set19/set196/set1965/a/solution_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect string) {
+	t.Helper()
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Fatalf("expect %q, got %q for input:\n%s", expect, res, s)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, `5
+3 3 3 3 3`, Alice)
+}
+
+func TestStatementSamples(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"one_and_seven", `2
+1 7`, Bob},
+		{"seven_distinct", `7
+1 3 9 7 4 2 100`, Alice},
+		{"one_two_three", `3
+1 2 3`, Alice},
+		{"six_with_dupes", `6
+2 1 3 4 2 4`, Bob},
+		{"eight_mixed", `8
+5 7 2 9 6 3 3 2`, Alice},
+		{"single_large", `1
+1000000000`, Alice},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runSample(t, tc.input, tc.expect)
+		})
+	}
+}
+
+func TestEdgeCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"single_one", `1
+1`, Alice},
+		{"two_consecutive", `2
+1 2`, Bob},
+		{"two_equal", `2
+5 5`, Alice},
+		{"two_gap_two", `2
+2 4`, Alice},
+		{"three_all_same", `3
+10 10 10`, Alice},
+		{"two_one_one", `2
+1 1`, Alice},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runSample(t, tc.input, tc.expect)
+		})
+	}
+}

--- a/src/codeforces/set2/set22/set220/set2203/c/problem.md
+++ b/src/codeforces/set2/set22/set220/set2203/c/problem.md
@@ -1,0 +1,91 @@
+# Codeforces 2203C - Test Generator
+
+https://codeforces.com/problemset/problem/2203/C
+
+## Statement
+
+You are developing a test generator. It takes two integers `s` and `m` as input.
+You need to construct an array of non-negative integers:
+
+```text
+a = [a1, a2, ..., an]
+```
+
+such that:
+
+```text
+sum(a[i]) = s
+```
+
+and for each `i`:
+
+```text
+a[i] & m = a[i]
+```
+
+where `&` denotes the bitwise AND operator.
+
+In other words, in each number `a[i]`, bits set to `1` may appear only in
+positions where the corresponding bit of `m` is also `1`.
+
+Determine whether at least one such array exists. If it exists, find the minimum
+possible length `n`.
+
+## Input
+
+Each test contains multiple test cases.
+
+The first line contains the number of test cases `t` (`1 <= t <= 10^4`).
+
+Each test case consists of one line containing two integers `s` and `m`
+(`1 <= s, m <= 10^18`) — the parameters of the generator.
+
+## Output
+
+For each test case, print one integer:
+
+- if such an array does not exist, print `-1`;
+- otherwise, print the minimum possible value of `n`, the array length.
+
+## Sample
+
+```text
+6
+13 5
+13 3
+13 6
+1000000007 2776648
+99999999999 1
+998244353 1557287
+```
+
+```text
+3
+5
+-1
+-1
+99999999999
+642
+```
+
+## Note
+
+For `s = 13`, `m = 5`, the answer is `3`, because one suitable array is:
+
+```text
+[5, 4, 4]
+```
+
+For `s = 13`, `m = 3`, the answer is `5`, because one suitable array is:
+
+```text
+[3, 3, 3, 3, 1]
+```
+
+For `s = 13`, `m = 6`, the answer is `-1`, because no suitable array exists.
+
+
+### ideas
+1. a & m = a => a 是m的一个子集
+2. 考虑每一位的情况
+3. 

--- a/src/codeforces/set2/set22/set220/set2203/c/solution.go
+++ b/src/codeforces/set2/set22/set220/set2203/c/solution.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		var s, m int
+		fmt.Fscan(reader, &s, &m)
+		res := solve(s, m)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func solve(s int, m int) int {
+	h := bits.Len(uint(m))
+
+	check := func(n int) bool {
+		t := s
+		for d := h - 1; d >= 0; d-- {
+			if (m>>d)&1 == 1 {
+				w := min(n, t/(1<<d))
+				t -= w * (1 << d)
+			}
+		}
+
+		return t == 0
+	}
+	inf := s + 1
+	ans := sort.Search(inf, check)
+	if ans == inf {
+		return -1
+	}
+	return ans
+}

--- a/src/codeforces/set2/set22/set220/set2203/c/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2203/c/solution_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func runSample(t *testing.T, s int, m int, expect int) {
+	res := solve(s, m)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	runSample(t, 13, 5, 3)
+}
+
+func TestSample2(t *testing.T) {
+	runSample(t, 13, 3, 5)
+}
+
+func TestSample3(t *testing.T) {
+	runSample(t, 13, 6, -1)
+}
+
+func TestSample4(t *testing.T) {
+	runSample(t, 1000000007, 2776648, -1)
+}
+
+func TestSample5(t *testing.T) {
+	runSample(t, 99999999999, 1, 99999999999)
+}
+
+func TestSample6(t *testing.T) {
+	runSample(t, 998244353, 1557287, 642)
+}

--- a/src/codeforces/set2/set22/set220/set2207/b/problem.md
+++ b/src/codeforces/set2/set22/set220/set2207/b/problem.md
@@ -1,0 +1,217 @@
+# Codeforces 2207B - One Night At Freddy's
+
+https://codeforces.com/problemset/problem/2207/B
+
+## Statement
+
+Let `n`, `m`, and `l` be positive integers.
+
+You have made the unfortunate decision to work as a night guard at Freddy
+Fazbear's Pizzeria, where there are `m` animatronics numbered `1..m` waiting to
+jumpscare you.
+
+The night consists of `l` seconds, numbered `1..l`. The `j`-th animatronic has a
+danger level `dj`, and initially:
+
+```text
+d1 = d2 = ... = dm = 0
+```
+
+Every second, the danger level of exactly one animatronic increases by `1`.
+Throughout the night, you can observe all current values of `dj`.
+
+For example, if `m = 2`, one possible list of danger levels after `5` seconds is:
+
+```text
+[d1, d2] = [2, 3]
+```
+
+You are not defenseless. At each of the `n` fixed times `ai`
+(`1 <= a1 < a2 < ... < an <= l`), you can shine your flashlight on exactly one
+animatronic `ji` of your choice. This happens immediately after the `ai`-th
+second and sets its danger level back to zero:
+
+```text
+d[ji] := 0
+```
+
+The choice is made independently for each flashlight use.
+
+Continuing the example above, if `a1 = 5` and you choose to flash the second
+animatronic at that time, then the danger levels after `5` seconds become:
+
+```text
+[d1, d2] = [2, 0]
+```
+
+The overall danger is the maximum danger across all animatronics:
+
+```text
+max(dj) for 1 <= j <= m
+```
+
+You lose if the overall danger at the end of the night, after `l` seconds, is
+greater than `x`.
+
+Find the minimum value of `x` such that, regardless of the animatronics'
+actions, you can guarantee that the final overall danger is at most `x`.
+
+## Input
+
+Each test contains multiple test cases.
+
+The first line contains an integer `t` (`1 <= t <= 10^4`) — the number of test
+cases.
+
+For each test case:
+
+- The first line contains three integers `n`, `m`, and `l`
+  (`1 <= n, m, l <= 2 * 10^5`, `n <= l`, `1 <= m * l <= 2 * 10^5`) — the number
+  of flashlight actions, the number of animatronics, and the length of the
+  night.
+- The second line contains `n` integers `a1, a2, ..., an`
+  (`1 <= a1 < a2 < ... < an <= l`) — the times at which you can shine the
+  flashlight.
+
+It is guaranteed that the sum of `m * l` over all test cases does not exceed
+`2 * 10^5`.
+
+## Output
+
+For each test case, output a single integer: the minimum `x` such that you can
+guarantee the final danger level is at most `x`.
+
+## Sample
+
+```text
+7
+1 2 10
+10
+5 1 32
+1 4 9 16 25
+2 3 40
+13 37
+2 2 7
+6 7
+8 5 60
+3 17 20 28 36 44 45 50
+6 7 1987
+6 7 66 77 666 777
+1 1 1
+1
+```
+
+```text
+5
+7
+19
+1
+19
+1477
+0
+```
+
+## Note
+
+In the first test case, there are `2` animatronics and the night length is `10`.
+You can flash after the `10`-th second. For `x = 5`, after `10` seconds, one
+animatronic must have at least `5` danger and the other has at most `5` danger.
+Flash the one with higher danger, and the final danger is at most `5`. It can be
+shown that `5` is minimum.
+
+In the second test case, there is only one animatronic and the night length is
+`32`. The animatronic's danger increases by `1` every second. After the `25`-th
+second, reset it to `0`; then `7` more seconds pass before the night ends, so the
+final danger is always `7`.
+
+In the third test case, it can be proven that the minimum possible value of `x`
+is `19`.
+
+### ideas
+1. 假设a[m]的时候，将某个怪物照射了，那么在接下来的l - a[m]+1的时间内，就没有机会，那么就让它生长是最优的
+2. x >= l - a[m] + 1
+3. 然后考虑a[m-1], 如果它是最后一次（虽然不是），那么x >= l - a[m-1] + 1, 
+4. 但是因为还有一次照射，最好的方案是各张一半，x/2, x - x/2， 然后多的那个被照射，剩下的（a[m] - a[m-1] + 1）/2 + l - a[m] + 1
+5. 考虑m-2. 一样的逻辑？
+6. 怪兽的数量没有考虑？
+
+## Solution
+
+At any flashlight time, the best choice is to reset an animatronic with maximum
+current danger. Resetting a smaller danger while a larger one remains can only
+make the final maximum worse.
+
+Now suppose there are `k` flashlight uses remaining. Only the largest `k + 1`
+danger levels matter:
+
+- At most `k` animatronics can still be reset before the end.
+- So even if we reset the largest `k` among the dangerous ones, the final answer
+  is still controlled by the next one.
+- Any animatronic outside the largest `k + 1` cannot become the final maximum
+  unless it first enters this tracked set.
+
+Therefore, while there are `k` flashes remaining, we maintain only:
+
+```text
+min(m, k + 1)
+```
+
+danger levels, sorted in descending order.
+
+## Adversary move
+
+Each second, the animatronics choose one danger level to increase by `1`.
+
+To maximize the eventual final maximum among the tracked values, the adversary
+should increase the smallest tracked value. This is the usual balancing
+strategy: increasing a larger value can be erased by a future flashlight, while
+raising the smallest tracked value increases the lower part of the top
+`k + 1` values.
+
+So every second:
+
+```text
+increase the last element of the descending sorted tracked list
+sort descending again
+```
+
+The constraints allow this direct simulation, because:
+
+```text
+sum(m * l) <= 2 * 10^5
+```
+
+## Flashlight move
+
+If a flashlight is available at the current second:
+
+1. Remove the largest tracked danger level. This represents resetting the most
+   dangerous animatronic to `0`.
+2. Decrease the number of remaining flashes.
+3. If the tracked list should still contain more values, append a `0`. This
+   represents another currently harmless animatronic becoming relevant.
+4. Sort descending again.
+
+The target tracked size after the flash is:
+
+```text
+min(m, remaining_flashes + 1)
+```
+
+At the end of all `l` seconds, the answer is the largest value in the tracked
+list.
+
+## Complexity
+
+The tracked list has length at most `m`. Each second sorts this list, so the
+implementation is easily fast enough under the given constraint:
+
+```text
+O(l * m log m)
+```
+
+over each test case, with:
+
+```text
+sum(m * l) <= 2 * 10^5
+```

--- a/src/codeforces/set2/set22/set220/set2207/b/solution.go
+++ b/src/codeforces/set2/set22/set220/set2207/b/solution.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"slices"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		fmt.Fprintln(writer, drive(reader))
+	}
+}
+
+func drive(reader *bufio.Reader) int {
+	var n, m, l int
+	fmt.Fscan(reader, &n, &m, &l)
+	a := make([]int, n)
+	for i := range n {
+		fmt.Fscan(reader, &a[i])
+	}
+	return solve(m, l, a)
+}
+
+func solve(m int, l int, a []int) int {
+	n := len(a)
+	left := n
+	k := min(m, left+1)
+	level := make([]int, k)
+
+	for t := 1; t <= l; t++ {
+		level[len(level)-1]++
+		slices.SortFunc(level, func(a, b int) int {
+			return b - a
+		})
+
+		if left > 0 && a[n-left] == t {
+			level = level[1:]
+			left--
+			want := min(m, left+1)
+			if len(level) < want {
+				level = append(level, 0)
+			}
+		}
+	}
+
+	if len(level) == 0 {
+		return 0
+	}
+	return level[0]
+}

--- a/src/codeforces/set2/set22/set220/set2207/b/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2207/b/solution_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect int) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %d, but got %d", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `1 2 10
+10
+`
+	expect := 5
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `5 1 32
+1 4 9 16 25
+`
+	expect := 7
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `2 3 40
+13 37
+`
+	expect := 19
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `2 2 7
+6 7
+`
+	expect := 1
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `8 5 60
+3 17 20 28 36 44 45 50
+`
+	expect := 19
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `6 7 1987
+6 7 66 77 666 777
+`
+	expect := 1477
+	runSample(t, s, expect)
+}
+
+func TestSample7(t *testing.T) {
+	s := `1 1 1
+1
+`
+	expect := 0
+	runSample(t, s, expect)
+}

--- a/src/codeforces/set2/set22/set220/set2207/d/problem.md
+++ b/src/codeforces/set2/set22/set220/set2207/d/problem.md
@@ -1,0 +1,333 @@
+# Codeforces 2207D - Boxed Like a Fish
+
+https://codeforces.com/problemset/problem/2207/D
+
+## Statement
+
+Let `n` and `k` be positive integers. You are given a tree with `n` vertices
+numbered `1..n`.
+
+Cyndaquil is traversing this tree and is trying to reach one of its leaves.
+Initially, he starts at a non-leaf vertex `v`. In one turn, he may either stay
+still or move from his current vertex along an edge to any neighboring vertex.
+
+Snorlax is trying to stop Cyndaquil by sleeping on an edge. When Snorlax chooses
+an edge, Cyndaquil is blocked from traversing that edge until Snorlax moves
+again. Only one edge may be blocked at a time, so only the most recently chosen
+edge is blocked.
+
+Snorlax is slow and has a cooldown timer, initially `0`. He may choose a new edge
+only when the cooldown is `0` or lower, though he does not have to choose one
+immediately. When he moves to a new edge, the timer is reset to `k`. After each
+of Cyndaquil's turns, even if Cyndaquil stays still, the cooldown timer
+decreases by `1`.
+
+They take turns as described, with Snorlax acting first. Initially, Snorlax is
+not sleeping on any edge.
+
+Assuming both play optimally, determine whether Cyndaquil can always reach a
+leaf after a finite number of turns.
+
+A tree is a connected graph without cycles.
+
+A leaf is a vertex with degree `1`.
+
+## Input
+
+Each test contains multiple test cases.
+
+The first line contains the number of test cases `t` (`1 <= t <= 10^4`).
+
+For each test case:
+
+- The first line contains three integers `n`, `k`, and `v`
+  (`3 <= n <= 5 * 10^5`, `1 <= k, v <= n`) — the number of vertices, Snorlax's
+  cooldown timer, and Cyndaquil's starting vertex.
+- The next `n - 1` lines each contain two integers `a` and `b`
+  (`1 <= a, b <= n`, `a != b`), describing an edge between vertices `a` and `b`.
+
+It is guaranteed that:
+
+- the edges form a tree;
+- `v` is not a leaf;
+- the sum of `n` over all test cases does not exceed `5 * 10^5`.
+
+## Output
+
+For each test case, print `YES` if Cyndaquil can always reach a leaf in a finite
+number of turns. Otherwise, print `NO`.
+
+You may print the answer in any letter case.
+
+## Sample
+
+```text
+6
+6 2 1
+1 2
+2 3
+2 4
+1 5
+5 6
+7 1 4
+1 2
+2 3
+3 4
+4 5
+5 6
+6 7
+3 1 3
+1 3
+2 3
+4 1 4
+1 3
+3 4
+4 2
+9 3 5
+4 5
+5 6
+4 7
+9 8
+8 7
+1 2
+2 3
+3 4
+9 4 5
+4 5
+5 6
+4 7
+9 8
+8 7
+1 2
+2 3
+3 4
+```
+
+```text
+YES
+NO
+YES
+NO
+NO
+YES
+```
+
+## Note
+
+In the first test case, Cyndaquil starts at vertex `1`. If Snorlax blocks the
+edge from `1` to `2`, then Cyndaquil can reach vertex `6` after two turns, which
+is a leaf. Otherwise, Cyndaquil can advance to vertex `2`, from which Snorlax
+cannot stop him from reaching at least one of vertices `3` and `4`.
+
+In the second test case, Snorlax can block Cyndaquil indefinitely from reaching
+either leaf `1` or leaf `7`.
+
+## Solution
+
+Root the tree at Cyndaquil's starting vertex `v`.
+
+We classify vertices as **winning** for Cyndaquil in the following sense:
+
+If Cyndaquil can reach such a vertex while Snorlax's cooldown is `0`, then
+Cyndaquil can force reaching some leaf in a finite number of turns.
+
+Every leaf is winning, because if Cyndaquil is already at a leaf, he has
+succeeded.
+
+For an internal vertex `u`, the question is whether Cyndaquil has enough
+different child directions to outrun Snorlax's cooldown.
+
+## Why only two best child directions matter
+
+Suppose Cyndaquil is at vertex `u` and Snorlax's cooldown is `0`.
+
+For each child subtree of `u`, there are two closely related distances:
+
+- `dp[c]`: distance from child `c` to the nearest winning vertex inside `c`'s
+  subtree;
+- `dp[c] + 1`: distance from `u` to that same winning vertex, because we first
+  cross the edge `u -> c`.
+
+In the implementation, the two smallest child values are usually kept before
+adding this extra edge:
+
+```text
+first  <= second       // these are child dp values
+```
+
+In the explanation below, let:
+
+```text
+d1 = first + 1
+d2 = second + 1
+```
+
+These are the two smallest distances measured from `u`.
+
+If there is only one such direction, Snorlax can always block that unique escape
+direction when ready, so it cannot make `u` winning by itself.
+
+Now suppose there are two directions. Snorlax can block one edge or wait and
+block the final edge toward the first direction Cyndaquil commits to. If
+Cyndaquil turns back and tries the second direction, Snorlax needs cooldown time
+before he can move the block there.
+
+The important quantity is the time needed to go from the first winning direction
+to the second through `u`.
+
+If the nearest winning vertices are at distances `d1` and `d2` from `u`, then
+the time pressure is:
+
+```text
+d1 + d2 - 1
+```
+
+The `-1` appears because Snorlax blocks when Cyndaquil is one edge away from the
+first winning point; from that moment, Cyndaquil turns around and starts using
+the other direction.
+
+So if:
+
+```text
+d1 + d2 - 1 <= k
+```
+
+then Snorlax's cooldown is too slow: after blocking one direction, he cannot
+recover fast enough to also block the other before Cyndaquil reaches a winning
+position. Thus `u` itself is winning.
+
+Equivalently:
+
+```text
+d1 + d2 <= k + 1
+```
+
+Substituting `d1 = first + 1` and `d2 = second + 1` gives:
+
+```text
+first + second + 1 <= k
+```
+
+With integer values, this is the same as:
+
+```text
+first + second < k
+```
+
+This is why an implementation may use `first + second < k`, even though the
+distance-from-`u` explanation naturally writes `best1 + best2 - 1 <= k`.
+
+If this condition is false, Snorlax can keep waiting and blocking the currently
+threatened direction, forcing Cyndaquil to return before reaching a winning
+position.
+
+## Tree DP
+
+Let:
+
+```text
+dp[u] = shortest distance from u to a winning vertex inside u's rooted subtree
+```
+
+If `u` itself is winning, then:
+
+```text
+dp[u] = 0
+```
+
+For a leaf:
+
+```text
+dp[u] = 0
+```
+
+For an internal vertex, compute all child values:
+
+```text
+child value from c = dp[c]
+```
+
+Let `first` and `second` be the two smallest child values. If both exist and:
+
+```text
+first + second < k
+```
+
+then `u` is winning, so:
+
+```text
+dp[u] = 0
+```
+
+If instead you define:
+
+```text
+best1 = first + 1
+best2 = second + 1
+```
+
+as the two smallest distances from `u`, the same condition is:
+
+```text
+best1 + best2 - 1 <= k
+```
+
+These two forms are equivalent.
+
+Otherwise, `u` is not immediately winning, and the nearest winning vertex in
+`u`'s subtree is reached through the best child:
+
+```text
+dp[u] = first + 1
+```
+
+After the DFS finishes, Cyndaquil can force a win if and only if:
+
+```text
+dp[v] = 0
+```
+
+## Why this is sufficient
+
+The recurrence captures both players' optimal strategies.
+
+For Cyndaquil:
+
+- If he reaches a winning vertex with cooldown `0`, by definition he can force a
+  leaf.
+- If a vertex has two sufficiently close winning child directions, Snorlax can
+  block at most one of them before cooldown prevents switching quickly enough.
+
+For Snorlax:
+
+- If a vertex has fewer than two winning directions, there is no fork to exploit.
+- If the two nearest winning directions are still too far apart, then every pair
+  of directions is too far apart. Snorlax can wait, block the direction
+  Cyndaquil is about to complete, and recover in time before Cyndaquil can
+  convert the detour into another winning position.
+
+Thus the two smallest child distances completely determine whether `u` becomes
+winning.
+
+## Complexity
+
+Root the tree once at `v` and run one DFS. Each edge is processed once.
+
+The total complexity is:
+
+```text
+O(n)
+```
+
+per test case, with `O(n)` memory.
+
+
+### ideas
+1. 如果v已经是leaf， yes
+2. Snorlax如果要阻拦，肯定是阻拦Cyndaquil下一个要选择的边（但不一定是最近的那条边）
+3. dp[v]表示在子树v中阻止Cyndaquil到达叶子节点，需要的最小的cooldown时间
+4. dp[v] = 0 if v is leaf
+5. else, 如果u只有一个叶子节点dp[u] = dp[v] + 1 ? 只需要在从v中到达叶子节点前，进行阻拦即可
+6. 如果u有多个叶子节点， sort, dp[v]; 如果存在任何两个以上相同的dp[v], dp[u] = dp[v] + 1 (这是因为，Snorlax)只能防治一个
+7. 否则 dp[u] = max(dp[v]) + 1 (前面的依次预防都可以做到，只有最后一个才能稳定到达)
+8. 

--- a/src/codeforces/set2/set22/set220/set2207/d/solution.go
+++ b/src/codeforces/set2/set22/set220/set2207/d/solution.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var tc int
+	fmt.Fscan(reader, &tc)
+	for range tc {
+		res := drive(reader)
+		if res {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}
+
+func drive(reader *bufio.Reader) bool {
+	var n, k, v int
+	fmt.Fscan(reader, &n, &k, &v)
+	edges := make([][]int, n-1)
+	for i := range n - 1 {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		edges[i] = []int{a, b}
+	}
+	return solve(n, edges, k, v)
+}
+
+type pair struct {
+	first  int
+	second int
+}
+
+const inf = 1 << 30
+
+func solve(n int, edges [][]int, k int, root int) bool {
+	root--
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+
+	var dfs func(p int, u int) int
+	dfs = func(p int, u int) int {
+		first, second := inf, inf
+		for _, v := range adj[u] {
+			if p != v {
+				tmp := dfs(u, v)
+				if tmp <= first {
+					second = first
+					first = tmp
+				} else if tmp <= second {
+					second = tmp
+				}
+			}
+		}
+		if first == inf {
+			return 0
+		}
+		if second == inf {
+			return first + 1
+		}
+		if first+second < k {
+			return 0
+		}
+		return first + 1
+	}
+
+	return dfs(-1, root) == 0
+}

--- a/src/codeforces/set2/set22/set220/set2207/d/solution_test.go
+++ b/src/codeforces/set2/set22/set220/set2207/d/solution_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func runSample(t *testing.T, s string, expect bool) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	res := drive(reader)
+	if res != expect {
+		t.Errorf("Sample expect %t, but got %t", expect, res)
+	}
+}
+
+func TestSample1(t *testing.T) {
+	s := `6 2 1
+1 2
+2 3
+2 4
+1 5
+5 6
+`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample2(t *testing.T) {
+	s := `7 1 4
+1 2
+2 3
+3 4
+4 5
+5 6
+6 7
+`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample3(t *testing.T) {
+	s := `3 1 3
+1 3
+2 3
+`
+	expect := true
+	runSample(t, s, expect)
+}
+
+func TestSample4(t *testing.T) {
+	s := `4 1 4
+1 3
+3 4
+4 2
+`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample5(t *testing.T) {
+	s := `9 3 5
+4 5
+5 6
+4 7
+9 8
+8 7
+1 2
+2 3
+3 4
+`
+	expect := false
+	runSample(t, s, expect)
+}
+
+func TestSample6(t *testing.T) {
+	s := `9 4 5
+4 5
+5 6
+4 7
+9 8
+8 7
+1 2
+2 3
+3 4
+`
+	expect := true
+	runSample(t, s, expect)
+}


### PR DESCRIPTION
## Summary
- Add Codeforces problem packages with statements, solutions, and tests for 57D, 121D, 1965A, 2203C, and 2207 B/D.

## Test plan
- [ ] `go test ./src/codeforces/set0/set0/set050/set057/d/`
- [ ] `go test ./src/codeforces/set0/set1/set120/set121/d/`
- [ ] `go test ./src/codeforces/set1/set19/set196/set1965/a/`
- [ ] `go test ./src/codeforces/set2/set22/set220/set2203/c/`
- [ ] `go test ./src/codeforces/set2/set22/set220/set2207/b/`
- [ ] `go test ./src/codeforces/set2/set22/set220/set2207/d/`

Made with [Cursor](https://cursor.com)