### PR TITLE
Add Aug 6 learning timeline for CF 2233D, 2244G, 2248E

### DIFF
--- a/docs/timeline/2026-08-06.md
+++ b/docs/timeline/2026-08-06.md
@@ -1,0 +1,5 @@
+# Learning Timeline — 2026-08-06
+
+- [Codeforces 2233D](../../src/codeforces/set2/set22/set223/set2233/d/): A shelf is correct when every value’s occurrences form one block; find the first short block of `x`, then try the few swaps that pull an adjacent outsider into `[L,R]` or push an interior non-`x` to an endpoint, and recheck block lengths.
+- [Codeforces 2244G](../../src/codeforces/set2/set22/set224/set2244/g/): Max-weight subset with `|i-j| > max(a_i,a_j)` is a left-to-right DP: after `i`’s block ends at `i+a_i`, store `dp[i]` in a Fenwick max-tree and query prefix `j-a_j-1` for the best compatible predecessor.
+- [Codeforces 2248E](../../src/codeforces/set2/set22/set224/set2248/e/): Beating all-ones of the same length reduces to two one-runs `I(x),0,I(y)` with `S_x+S_y > S_{x+y+1}`; only reward lengths `x,y ∈ p` need checking via the periodic score helper.

--- a/docs/timeline/README.md
+++ b/docs/timeline/README.md
@@ -1,7 +1,8 @@
 # Learning Timeline
 
-<!-- through-commit: 3bd5300b750c3af7c1f4f0bcc787a6b132ff84ca -->
+<!-- through-commit: b71ec84d604bad3f6023d4ee7152398b7517d11d -->
 
+- [2026-08-06](2026-08-06.md)
 - [2026-08-04](2026-08-04.md)
 - [2026-08-03](2026-08-03.md)
 - [2026-08-01](2026-08-01.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Record learning-timeline entries for the newly added packages and advance the through-commit marker.

### Recorded
- **2233D** — at-most-one swap to make equal values contiguous
- **2244G** — max-weight subset with separation via Fenwick DP
- **2248E** — beat all-ones score with two reward-length one-runs

### Verification
Final `discover.py` run returns `packages: []` with marker at `b71ec84d6…`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59493121-edc6-45d1-a62b-4915f5c00d2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59493121-edc6-45d1-a62b-4915f5c00d2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

